### PR TITLE
Ensure server A Dockerfile installs Go modules

### DIFF
--- a/sms-gateway-project/backend-server-a/Dockerfile
+++ b/sms-gateway-project/backend-server-a/Dockerfile
@@ -2,7 +2,8 @@
 FROM golang:1.21-alpine AS builder
 WORKDIR /app
 COPY . .
-RUN go build -o backend-server-a ./cmd/api
+RUN go mod tidy && \
+    go build -o backend-server-a ./cmd/api
 
 # Stage 2: Final
 FROM alpine:latest


### PR DESCRIPTION
## Summary
- run `go mod tidy` before building backend server A image

## Testing
- `go mod tidy` *(fails: Forbidden: https://proxy.golang.org/github.com/gin-gonic/gin/@v/v1.10.0.zip)*

------
https://chatgpt.com/codex/tasks/task_b_68a59fc5a45483208328c094f6e5e6a3