### PR TITLE
Ensure git available during backend-server-a build

### DIFF
--- a/sms-gateway-project/backend-server-a/Dockerfile
+++ b/sms-gateway-project/backend-server-a/Dockerfile
@@ -1,6 +1,7 @@
 # Stage 1: Build
 FROM golang:1.21-alpine AS builder
 WORKDIR /app
+RUN apk add --no-cache git
 COPY . .
 RUN go mod tidy && \
     go build -o backend-server-a ./cmd/api


### PR DESCRIPTION
## Summary
- install git in backend-server-a Docker build stage so Go modules can be fetched

## Testing
- `docker build -t backend-server-a-test sms-gateway-project/backend-server-a` *(fails: command not found)*
- `cd sms-gateway-project/backend-server-a && go build ./cmd/api` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_b_68a5a1df35808320a328182fa623adc0