### PR TITLE
fix: ensure Go builds modules when building backend B

### DIFF
--- a/sms-gateway-project/backend-server-b/Dockerfile
+++ b/sms-gateway-project/backend-server-b/Dockerfile
@@ -5,7 +5,7 @@ COPY go.mod go.sum .
 COPY internal ./internal
 COPY cmd ./cmd
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o sms-server ./cmd/api
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=mod -o sms-server ./cmd/api
 
 # Stage 2: final image
 FROM alpine:3.18


### PR DESCRIPTION
## Summary
- allow `go build` to resolve missing module sums for backend-server-b

## Testing
- `go build -mod=mod -o sms-server ./cmd/api` *(fails: unable to access remote modules)*

------
https://chatgpt.com/codex/tasks/task_b_68a5a27f56b48320bc4b17bd066c90cc