### PR TITLE
feat(frontend): scaffold React app with routing and pages

### DIFF
--- a/sms-gateway-project/README.md
+++ b/sms-gateway-project/README.md
@@ -1,1 +1,23 @@
 # SMS Gateway Project
+
+This repository contains the SMS Gateway system with backend services and a React frontend.
+
+## Frontend
+
+The React application lives in `frontend/` and was bootstrapped with Vite.
+
+### Development
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### Production Build
+
+```bash
+npm run build
+```
+
+The frontend relies on Material UI, React Router, Axios, and date-fns for its UI and data handling.

--- a/sms-gateway-project/frontend/.env
+++ b/sms-gateway-project/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8081

--- a/sms-gateway-project/frontend/.eslintrc.cjs
+++ b/sms-gateway-project/frontend/.eslintrc.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  plugins: ['react-refresh'],
+  settings: {
+    react: { version: '18.2' }
+  },
+  rules: {}
+};

--- a/sms-gateway-project/frontend/.gitignore
+++ b/sms-gateway-project/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sms-gateway-project/frontend/index.html
+++ b/sms-gateway-project/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SMS Gateway</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/sms-gateway-project/frontend/package.json
+++ b/sms-gateway-project/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.14.0",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.0",
+    "react-router-dom": "^6.14.2",
+    "axios": "^1.4.0",
+    "date-fns": "^2.30.0",
+    "@mui/x-data-grid": "^6.0.0",
+    "@mui/x-date-pickers": "^6.0.0",
+    "@mui/lab": "^5.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.38.0",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.3.5",
+    "vite": "^4.3.9"
+  }
+}

--- a/sms-gateway-project/frontend/src/App.jsx
+++ b/sms-gateway-project/frontend/src/App.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Layout from './components/Layout.jsx';
+import ProtectedRoute from './components/ProtectedRoute.jsx';
+import AdminRoute from './components/AdminRoute.jsx';
+import LoginPage from './pages/LoginPage.jsx';
+import DashboardPage from './pages/DashboardPage.jsx';
+import MessageHistoryPage from './pages/MessageHistoryPage.jsx';
+import MessageDetailPage from './pages/MessageDetailPage.jsx';
+import ClientManagementPage from './pages/admin/ClientManagementPage.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+
+function App() {
+  return (
+    <AuthProvider>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <Router>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route element={<ProtectedRoute />}>
+              <Route element={<Layout />}>
+                <Route path="/" element={<DashboardPage />} />
+                <Route path="/messages" element={<MessageHistoryPage />} />
+                <Route path="/messages/:trackingId" element={<MessageDetailPage />} />
+                <Route element={<AdminRoute />}>
+                  <Route path="/admin/clients" element={<ClientManagementPage />} />
+                </Route>
+              </Route>
+            </Route>
+          </Routes>
+        </Router>
+      </LocalizationProvider>
+    </AuthProvider>
+  );
+}
+
+export default App;

--- a/sms-gateway-project/frontend/src/components/AdminRoute.jsx
+++ b/sms-gateway-project/frontend/src/components/AdminRoute.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const AdminRoute = () => {
+  const { user, isAuthenticated } = useAuth();
+  return isAuthenticated && user?.isAdmin ? <Outlet /> : <Navigate to="/" replace />;
+};
+
+export default AdminRoute;

--- a/sms-gateway-project/frontend/src/components/Layout.jsx
+++ b/sms-gateway-project/frontend/src/components/Layout.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { AppBar, Toolbar, Typography, Drawer, List, ListItem, ListItemText, Box } from '@mui/material';
+import { Link, Outlet } from 'react-router-dom';
+
+const drawerWidth = 240;
+
+const Layout = () => {
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+        <Toolbar>
+          <Typography variant="h6" noWrap component="div">SMS Gateway</Typography>
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box', mt: 8 }
+        }}
+      >
+        <List>
+          <ListItem button component={Link} to="/">
+            <ListItemText primary="Dashboard" />
+          </ListItem>
+          <ListItem button component={Link} to="/messages">
+            <ListItemText primary="Messages" />
+          </ListItem>
+          <ListItem button component={Link} to="/admin/clients">
+            <ListItemText primary="Clients" />
+          </ListItem>
+        </List>
+      </Drawer>
+      <Box component="main" sx={{ flexGrow: 1, p: 3, mt: 8 }}>
+        <Outlet />
+      </Box>
+    </Box>
+  );
+};
+
+export default Layout;

--- a/sms-gateway-project/frontend/src/components/ProtectedRoute.jsx
+++ b/sms-gateway-project/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const ProtectedRoute = () => {
+  const { isAuthenticated } = useAuth();
+  return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
+};
+
+export default ProtectedRoute;

--- a/sms-gateway-project/frontend/src/context/AuthContext.jsx
+++ b/sms-gateway-project/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState } from 'react';
+import apiService from '../services/apiService.js';
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('user');
+    return stored ? JSON.parse(stored) : null;
+  });
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const isAuthenticated = !!token;
+
+  const login = async (username, password) => {
+    const data = await apiService.login(username, password);
+    setUser(data.user);
+    setToken(data.token);
+    localStorage.setItem('user', JSON.stringify(data.user));
+    localStorage.setItem('token', data.token);
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem('user');
+    localStorage.removeItem('token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/sms-gateway-project/frontend/src/main.jsx
+++ b/sms-gateway-project/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/sms-gateway-project/frontend/src/pages/DashboardPage.jsx
+++ b/sms-gateway-project/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { Grid, Card, CardContent, Typography, CircularProgress, Alert } from '@mui/material';
+import apiService from '../services/apiService.js';
+
+const DashboardPage = () => {
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const data = await apiService.getDashboardStats();
+        setStats(data);
+      } catch (err) {
+        setError('Failed to load stats');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  if (loading) return <CircularProgress />;
+  if (error) return <Alert severity="error">{error}</Alert>;
+
+  return (
+    <Grid container spacing={2}>
+      {stats && Object.entries(stats).map(([key, value]) => (
+        <Grid item xs={12} md={4} key={key}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6">{key}</Typography>
+              <Typography variant="h4">{value}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};
+
+export default DashboardPage;

--- a/sms-gateway-project/frontend/src/pages/LoginPage.jsx
+++ b/sms-gateway-project/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Card, TextField, Button, Typography, Box, Alert } from '@mui/material';
+import { useAuth } from '../context/AuthContext.jsx';
+import { useNavigate } from 'react-router-dom';
+
+const LoginPage = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await login(username, password);
+      navigate('/');
+    } catch (err) {
+      setError(err.response?.data?.message || 'Login failed');
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+      <Card sx={{ p: 4, width: 400 }}>
+        <Typography variant="h5" gutterBottom>Login</Typography>
+        {error && <Alert severity="error">{error}</Alert>}
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField label="Username" fullWidth margin="normal" value={username} onChange={(e) => setUsername(e.target.value)} />
+          <TextField label="Password" type="password" fullWidth margin="normal" value={password} onChange={(e) => setPassword(e.target.value)} />
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>Login</Button>
+        </Box>
+      </Card>
+    </Box>
+  );
+};
+
+export default LoginPage;

--- a/sms-gateway-project/frontend/src/pages/MessageDetailPage.jsx
+++ b/sms-gateway-project/frontend/src/pages/MessageDetailPage.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Card, CardContent, Typography, CircularProgress, Alert } from '@mui/material';
+import { Timeline, TimelineItem, TimelineSeparator, TimelineConnector, TimelineContent, TimelineDot } from '@mui/lab';
+import apiService from '../services/apiService.js';
+
+const MessageDetailPage = () => {
+  const { trackingId } = useParams();
+  const [message, setMessage] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchMessage = async () => {
+      try {
+        const data = await apiService.getMessageDetails(trackingId);
+        setMessage(data);
+      } catch (err) {
+        setError('Failed to load message');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMessage();
+  }, [trackingId]);
+
+  if (loading) return <CircularProgress />;
+  if (error) return <Alert severity="error">{error}</Alert>;
+
+  return (
+    <div>
+      <Card sx={{ mb: 2 }}>
+        <CardContent>
+          <Typography variant="h6">Recipient: {message.recipient}</Typography>
+          <Typography>Status: {message.status}</Typography>
+          <Typography>Text: {message.text}</Typography>
+        </CardContent>
+      </Card>
+      <Timeline>
+        {message.events?.map((event, index) => (
+          <TimelineItem key={index}>
+            <TimelineSeparator>
+              <TimelineDot />
+              {index < message.events.length - 1 && <TimelineConnector />}
+            </TimelineSeparator>
+            <TimelineContent>
+              <Typography>{event.status}</Typography>
+              <Typography variant="caption">{event.timestamp}</Typography>
+            </TimelineContent>
+          </TimelineItem>
+        ))}
+      </Timeline>
+    </div>
+  );
+};
+
+export default MessageDetailPage;

--- a/sms-gateway-project/frontend/src/pages/MessageHistoryPage.jsx
+++ b/sms-gateway-project/frontend/src/pages/MessageHistoryPage.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { TextField, Select, MenuItem, Grid, Button } from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import { DatePicker } from '@mui/x-date-pickers';
+import { Link } from 'react-router-dom';
+import apiService from '../services/apiService.js';
+
+const MessageHistoryPage = () => {
+  const [filters, setFilters] = useState({ recipient: '', status: '', startDate: null, endDate: null });
+  const [messages, setMessages] = useState([]);
+  const [rowCount, setRowCount] = useState(0);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
+  const [loading, setLoading] = useState(false);
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const params = {
+        page: paginationModel.page + 1,
+        pageSize: paginationModel.pageSize,
+        recipient: filters.recipient || undefined,
+        status: filters.status || undefined,
+        startDate: filters.startDate ? filters.startDate.toISOString() : undefined,
+        endDate: filters.endDate ? filters.endDate.toISOString() : undefined
+      };
+      const data = await apiService.getMessages(params);
+      setMessages(data.items || []);
+      setRowCount(data.total || 0);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [filters, paginationModel]);
+
+  const columns = [
+    {
+      field: 'tracking_id',
+      headerName: 'Tracking ID',
+      width: 200,
+      renderCell: (params) => <Link to={`/messages/${params.value}`}>{params.value}</Link>
+    },
+    { field: 'recipient', headerName: 'Recipient', width: 150 },
+    { field: 'status', headerName: 'Status', width: 120 },
+    { field: 'provider', headerName: 'Provider', width: 150 },
+    { field: 'created_at', headerName: 'Created At', width: 200 }
+  ];
+
+  return (
+    <div style={{ height: 600, width: '100%' }}>
+      <Grid container spacing={2} sx={{ mb: 2 }}>
+        <Grid item>
+          <TextField label="Recipient" value={filters.recipient} onChange={(e) => setFilters({ ...filters, recipient: e.target.value })} />
+        </Grid>
+        <Grid item>
+          <Select displayEmpty value={filters.status} onChange={(e) => setFilters({ ...filters, status: e.target.value })}>
+            <MenuItem value="">All Statuses</MenuItem>
+            <MenuItem value="sent">Sent</MenuItem>
+            <MenuItem value="failed">Failed</MenuItem>
+          </Select>
+        </Grid>
+        <Grid item>
+          <DatePicker label="Start Date" value={filters.startDate} onChange={(newValue) => setFilters({ ...filters, startDate: newValue })} />
+        </Grid>
+        <Grid item>
+          <DatePicker label="End Date" value={filters.endDate} onChange={(newValue) => setFilters({ ...filters, endDate: newValue })} />
+        </Grid>
+        <Grid item>
+          <Button variant="outlined" onClick={fetchData}>Search</Button>
+        </Grid>
+      </Grid>
+      <DataGrid
+        rows={messages}
+        columns={columns}
+        rowCount={rowCount}
+        pageSizeOptions={[10, 25, 50]}
+        paginationModel={paginationModel}
+        paginationMode="server"
+        onPaginationModelChange={setPaginationModel}
+        loading={loading}
+        getRowId={(row) => row.tracking_id}
+      />
+    </div>
+  );
+};
+
+export default MessageHistoryPage;

--- a/sms-gateway-project/frontend/src/pages/admin/ClientManagementPage.jsx
+++ b/sms-gateway-project/frontend/src/pages/admin/ClientManagementPage.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { Button, Modal, Box, TextField } from '@mui/material';
+import apiService from '../../services/apiService.js';
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  p: 4
+};
+
+const ClientManagementPage = () => {
+  const [clients, setClients] = useState([]);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [quota, setQuota] = useState('');
+  const [editingClient, setEditingClient] = useState(null);
+
+  const fetchClients = async () => {
+    const data = await apiService.getClients();
+    setClients(data);
+  };
+
+  useEffect(() => {
+    fetchClients();
+  }, []);
+
+  const handleCreate = async () => {
+    if (editingClient) {
+      await apiService.updateClient(editingClient.id, { name, daily_quota: quota });
+    } else {
+      await apiService.createClient({ name, daily_quota: quota });
+    }
+    setOpen(false);
+    setName('');
+    setQuota('');
+    setEditingClient(null);
+    fetchClients();
+  };
+
+  const columns = [
+    { field: 'name', headerName: 'Name', flex: 1 },
+    { field: 'api_key', headerName: 'API Key', flex: 1 },
+    { field: 'daily_quota', headerName: 'Daily Quota', flex: 1 },
+    { field: 'is_active', headerName: 'Active', flex: 1 }
+  ];
+
+  return (
+    <div style={{ height: 500, width: '100%' }}>
+      <Button variant="contained" sx={{ mb: 2 }} onClick={() => setOpen(true)}>
+        Create New Client
+      </Button>
+      <DataGrid
+        rows={clients}
+        columns={columns}
+        getRowId={(row) => row.id}
+        onRowDoubleClick={(params) => {
+          setEditingClient(params.row);
+          setName(params.row.name);
+          setQuota(params.row.daily_quota);
+          setOpen(true);
+        }}
+      />
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <Box sx={style}>
+          <TextField label="Name" fullWidth margin="normal" value={name} onChange={(e) => setName(e.target.value)} />
+          <TextField label="Daily Quota" fullWidth margin="normal" value={quota} onChange={(e) => setQuota(e.target.value)} />
+          <Button variant="contained" onClick={handleCreate}>Save</Button>
+        </Box>
+      </Modal>
+    </div>
+  );
+};
+
+export default ClientManagementPage;

--- a/sms-gateway-project/frontend/src/services/apiService.js
+++ b/sms-gateway-project/frontend/src/services/apiService.js
@@ -1,0 +1,58 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+const login = async (username, password) => {
+  const response = await api.post('/login', { username, password });
+  return response.data;
+};
+
+const getDashboardStats = async () => {
+  const response = await api.get('/dashboard');
+  return response.data;
+};
+
+const getMessages = async (filters) => {
+  const response = await api.get('/messages', { params: filters });
+  return response.data;
+};
+
+const getMessageDetails = async (trackingId) => {
+  const response = await api.get(`/messages/${trackingId}`);
+  return response.data;
+};
+
+const getClients = async () => {
+  const response = await api.get('/admin/clients');
+  return response.data;
+};
+
+const createClient = async (clientData) => {
+  const response = await api.post('/admin/clients', clientData);
+  return response.data;
+};
+
+const updateClient = async (clientId, clientData) => {
+  const response = await api.put(`/admin/clients/${clientId}`, clientData);
+  return response.data;
+};
+
+export default {
+  login,
+  getDashboardStats,
+  getMessages,
+  getMessageDetails,
+  getClients,
+  createClient,
+  updateClient
+};

--- a/sms-gateway-project/frontend/vite.config.js
+++ b/sms-gateway-project/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- initialize Vite-based React frontend with MUI, React Router, Axios, and date-fns
- implement layout, auth context, API service, protected/admin routes, and key pages (login, dashboard, messages, message detail, client management)
- document frontend usage and environment configuration

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5a6efebf0832096cfd11beeece53c