### PR TITLE
feat: add logout functionality

### DIFF
--- a/sms-gateway-project/backend-server-b/cmd/api/main.go
+++ b/sms-gateway-project/backend-server-b/cmd/api/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"log"
 
-	"github.com/gin-gonic/gin"
 	"github.com/gin-contrib/cors"
-	"time" 
+	"github.com/gin-gonic/gin"
 	"sms-gateway/backend-server-b/internal/api"
 	"sms-gateway/backend-server-b/internal/config"
 	"sms-gateway/backend-server-b/internal/database"
@@ -13,6 +12,7 @@ import (
 	"sms-gateway/backend-server-b/internal/repository"
 	"sms-gateway/backend-server-b/internal/services"
 	"sms-gateway/backend-server-b/internal/worker"
+	"time"
 )
 
 func main() {
@@ -66,6 +66,7 @@ func main() {
 
 	authRoutes := r.Group("/api/auth")
 	authRoutes.POST("/login", handlers.LoginHandler)
+	authRoutes.POST("/logout", handlers.LogoutHandler)
 
 	apiRoutes := r.Group("/api")
 	apiRoutes.Use(api.AuthMiddleware(jwtSvc))

--- a/sms-gateway-project/backend-server-b/internal/api/logout_handler_test.go
+++ b/sms-gateway-project/backend-server-b/internal/api/logout_handler_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"sms-gateway/backend-server-b/internal/services"
+)
+
+func TestLogoutHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	jwtSvc := services.NewJWTService("secret")
+	token, err := jwtSvc.GenerateToken("user", 1, false)
+	if err != nil {
+		t.Fatalf("could not generate token: %v", err)
+	}
+	h := NewHandlers(nil, nil, jwtSvc)
+	r := gin.Default()
+	r.POST("/api/auth/logout", h.LogoutHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	// subsequent request with same token should be unauthorized
+	req2 := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req2.Header.Set("Authorization", "Bearer "+token)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w2.Code)
+	}
+}

--- a/sms-gateway-project/frontend/src/components/Layout.jsx
+++ b/sms-gateway-project/frontend/src/components/Layout.jsx
@@ -1,15 +1,25 @@
 import React from 'react';
-import { Link, Outlet } from 'react-router-dom';
+import { Link, Outlet, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
 
 const Layout = () => {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
   return (
     <div className="flex min-h-screen flex-col">
       <header className="flex items-center justify-between whitespace-nowrap border-b border-gray-200 px-10 py-3">
         <h1 className="text-lg font-bold text-gray-900">SMS Gateway</h1>
-        <nav className="flex gap-9 text-gray-900">
+        <nav className="flex gap-9 text-gray-900 items-center">
           <Link className="text-sm font-medium" to="/">Dashboard</Link>
           <Link className="text-sm font-medium" to="/messages">Messages</Link>
           <Link className="text-sm font-medium" to="/admin/clients">Clients</Link>
+          <button className="text-sm font-medium" onClick={handleLogout}>Logout</button>
         </nav>
       </header>
       <main className="flex-1 px-40 py-5">

--- a/sms-gateway-project/frontend/src/context/AuthContext.jsx
+++ b/sms-gateway-project/frontend/src/context/AuthContext.jsx
@@ -22,12 +22,13 @@ export const AuthProvider = ({ children }) => {
     localStorage.setItem('token', data.token);
   };
 
-  const logout = () => {
-    setUser(null);
-    setToken(null);
-    localStorage.removeItem('user');
-    localStorage.removeItem('token');
-  };
+    const logout = async () => {
+      await apiService.logout();
+      setUser(null);
+      setToken(null);
+      localStorage.removeItem('user');
+      localStorage.removeItem('token');
+    };
 
   return (
     <AuthContext.Provider value={{ user, token, isAuthenticated, login, logout }}>

--- a/sms-gateway-project/frontend/src/services/apiService.js
+++ b/sms-gateway-project/frontend/src/services/apiService.js
@@ -17,6 +17,10 @@ const login = async (username, password) => {
   return response.data;
 };
 
+const logout = async () => {
+  await api.post('/auth/logout');
+};
+
 const getDashboardStats = async () => {
   const response = await api.get('/dashboard');
   return response.data;
@@ -49,6 +53,7 @@ const updateClient = async (clientId, clientData) => {
 
 export default {
   login,
+  logout,
   getDashboardStats,
   getMessages,
   getMessageDetails,


### PR DESCRIPTION
## Summary
- add JWT token revocation and logout endpoint to backend
- expose logout API call and button in frontend
- ensure logout removes user session

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*
- `go test ./...` *(fails: missing go.sum entries for github.com/golang-jwt/jwt/v5)*

------
https://chatgpt.com/codex/tasks/task_b_68a78a47475c83209c07dba54428135e