### PR TITLE
Add user editing capability to admin panel

### DIFF
--- a/sms-gateway-project/backend-server-b/cmd/api/main.go
+++ b/sms-gateway-project/backend-server-b/cmd/api/main.go
@@ -79,6 +79,7 @@ func main() {
 	userRoutes.Use(api.AdminOnlyMiddleware())
 	userRoutes.GET("", handlers.ListUsersHandler)
 	userRoutes.POST("", handlers.CreateUserHandler)
+	userRoutes.PUT(":id", handlers.UpdateUserHandler)
 	userRoutes.DELETE(":id", handlers.DeleteUserHandler)
 	userRoutes.POST(":id/activate", handlers.ActivateUserHandler)
 	userRoutes.POST(":id/deactivate", handlers.DeactivateUserHandler)

--- a/sms-gateway-project/backend-server-b/internal/api/update_user_handler_test.go
+++ b/sms-gateway-project/backend-server-b/internal/api/update_user_handler_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"sms-gateway/backend-server-b/internal/models"
+	"sms-gateway/backend-server-b/internal/repository"
+)
+
+func TestUpdateUserHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	if err := db.AutoMigrate(&models.UIUser{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	repo := repository.NewUserRepository(db)
+	user := models.UIUser{Username: "user1", Name: "User One", Password: "pass", IsActive: true}
+	if err := repo.CreateUser(&user); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	h := NewHandlers(nil, repo, nil)
+	r := gin.Default()
+	r.PUT("/users/:id", h.UpdateUserHandler)
+
+	payload := `{"username":"user1","name":"Updated","phone":"","extension":"","department":"","password":"","api_key":"","daily_quota":0,"is_admin":false,"is_active":true}`
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/users/%d", user.ID), strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	updated, err := repo.GetUserByID(user.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Name != "Updated" {
+		t.Fatalf("expected name to be Updated, got %s", updated.Name)
+	}
+}

--- a/sms-gateway-project/frontend/src/pages/admin/UserManagementPage.jsx
+++ b/sms-gateway-project/frontend/src/pages/admin/UserManagementPage.jsx
@@ -16,6 +16,7 @@ const style = {
 const UserManagementPage = () => {
   const [users, setUsers] = useState([]);
   const [open, setOpen] = useState(false);
+  const [editingId, setEditingId] = useState(null);
   const [username, setUsername] = useState('');
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
@@ -48,20 +49,7 @@ const UserManagementPage = () => {
     fetchUsers();
   }, []);
 
-  const handleCreate = async () => {
-    await apiService.createUser({
-      username,
-      name,
-      phone,
-      extension,
-      department,
-      password,
-      api_key: apiKey,
-      daily_quota: dailyQuota,
-      is_admin: isAdmin,
-      is_active: isActive
-    });
-    setOpen(false);
+  const resetForm = () => {
     setUsername('');
     setName('');
     setPhone('');
@@ -72,6 +60,50 @@ const UserManagementPage = () => {
     setDailyQuota('');
     setIsAdmin(false);
     setIsActive(true);
+  };
+
+  const handleOpenCreate = () => {
+    setEditingId(null);
+    resetForm();
+    setOpen(true);
+  };
+
+  const handleOpenEdit = (user) => {
+    setEditingId(user.id);
+    setUsername(user.username);
+    setName(user.name);
+    setPhone(user.phone);
+    setExtension(user.extension);
+    setDepartment(user.department);
+    setPassword('');
+    setApiKey(user.api_key);
+    setDailyQuota(user.daily_quota);
+    setIsAdmin(user.is_admin);
+    setIsActive(user.is_active);
+    setOpen(true);
+  };
+
+  const handleSave = async () => {
+    const payload = {
+      username,
+      name,
+      phone,
+      extension,
+      department,
+      password,
+      api_key: apiKey,
+      daily_quota: dailyQuota,
+      is_admin: isAdmin,
+      is_active: isActive
+    };
+    if (editingId) {
+      await apiService.updateUser(editingId, payload);
+    } else {
+      await apiService.createUser(payload);
+    }
+    setOpen(false);
+    resetForm();
+    setEditingId(null);
     fetchUsers();
   };
 
@@ -105,12 +137,11 @@ const UserManagementPage = () => {
       flex: 1,
       renderCell: (params) => (
         <>
+          <Button onClick={() => handleOpenEdit(params.row)} size="small">Edit</Button>
           <Button onClick={() => handleToggleActive(params.row)} size="small">
             {params.row.is_active ? 'Deactivate' : 'Activate'}
           </Button>
-          <Button onClick={() => handleDelete(params.row.id)} size="small" color="error">
-            Delete
-          </Button>
+          <Button onClick={() => handleDelete(params.row.id)} size="small" color="error">Delete</Button>
         </>
       )
     }
@@ -118,7 +149,7 @@ const UserManagementPage = () => {
 
   return (
     <div style={{ height: 500, width: '100%' }}>
-      <Button variant="contained" sx={{ mb: 2 }} onClick={() => setOpen(true)}>
+      <Button variant="contained" sx={{ mb: 2 }} onClick={handleOpenCreate}>
         Create New User
       </Button>
       <DataGrid rows={users} columns={columns} getRowId={(row) => row.id} />
@@ -134,7 +165,7 @@ const UserManagementPage = () => {
           <TextField label="Daily Quota" fullWidth margin="normal" value={dailyQuota} onChange={(e) => setDailyQuota(e.target.value)} />
           <FormControlLabel control={<Checkbox checked={isAdmin} onChange={(e) => setIsAdmin(e.target.checked)} />} label="Admin" />
           <FormControlLabel control={<Checkbox checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />} label="Active" />
-          <Button variant="contained" onClick={handleCreate}>Save</Button>
+          <Button variant="contained" onClick={handleSave}>Save</Button>
         </Box>
       </Modal>
     </div>

--- a/sms-gateway-project/frontend/src/services/apiService.js
+++ b/sms-gateway-project/frontend/src/services/apiService.js
@@ -46,6 +46,11 @@ const createUser = async (userData) => {
   return response.data;
 };
 
+const updateUser = async (userId, userData) => {
+  const response = await api.put(`/users/${userId}`, userData);
+  return response.data;
+};
+
 const deleteUser = async (userId) => {
   await api.delete(`/users/${userId}`);
 };
@@ -66,6 +71,7 @@ export default {
   getMessageDetails,
   getUsers,
   createUser,
+  updateUser,
   deleteUser,
   activateUser,
   deactivateUser


### PR DESCRIPTION
## Summary
- allow admins to edit existing users via new update API and frontend modal
- expose updateUser API call and route
- add unit test for UpdateUserHandler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error for module syntax)*
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a79da499888320a0da9c9076a6154a