### PR TITLE
Add server-b processing backend with policy engine and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,16 @@ PROVIDERS_CONFIG={
   "Provider-B":{"is_active":false,"is_operational":false,"note":"disabled"},
   "Local-SMS":{"is_active":true,"is_operational":true,"note":"offline module"}
 }
+# Server B
+SERVICE_NAME=server-b
+SERVER_B_HOST=0.0.0.0
+SERVER_B_PORT=9000
+RABBITMQ_QUEUE_OUTBOUND=sms.outbound
+RABBITMQ_QUEUE_HEARTBEAT=a.heartbeat
+RABBITMQ_PREFETCH=32
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/smsgw
+MAX_SEND_ATTEMPTS=10
+DEFAULT_TTL_SECONDS=3600
+MIN_TTL_SECONDS=10
+MAX_TTL_SECONDS=86400
+SMART_SELECTION_STRATEGY=priority

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build up down logs lint fmt test
+.PHONY: build up down logs logs-b lint fmt test test-b
 
 build:
 	docker compose build
@@ -12,6 +12,9 @@ down:
 logs:
 	docker compose logs -f server-a
 
+logs-b:
+	docker compose logs -f server-b
+
 lint:
 	docker compose run --rm server-a ruff check .
 
@@ -20,3 +23,6 @@ fmt:
 
 test:
 	docker compose run --rm server-a pytest
+
+test-b:
+	docker compose run --rm server-b pytest

--- a/README.md
+++ b/README.md
@@ -4,36 +4,31 @@ This repository contains the components for an internal SMS API Gateway.
 
 ## Components
 
-*   **server-a**: The API Gateway component (FastAPI). Handles incoming SMS requests, authentication, validation, provider routing, quota management, and enqueues messages to RabbitMQ for Server B.
-*   **server-b**: (Placeholder) The backend worker that processes messages from RabbitMQ and dispatches them to external SMS providers.
-*   **frontend**: (Placeholder) A potential future web interface for managing the SMS gateway.
+* **server-a**: API Gateway (FastAPI) that enqueues messages to RabbitMQ.
+* **server-b**: Backend worker that consumes messages, applies provider policies, persists state in PostgreSQL and exposes status and webhook APIs.
+* **frontend**: Placeholder for future interface.
 
 ## Quickstart
 
-To get Server A, Redis, and RabbitMQ running locally using Docker Compose:
-
-1.  **Prerequisites:** Ensure Docker and Docker Compose are installed.
-2.  **Environment Variables:** Copy `.env.example` to `.env` and adjust as needed.
-    ```bash
-    cp .env.example .env
-    ```
-3.  **Build and Run:**
-    ```bash
-    make up
-    ```
-    This will build the `server-a` Docker image and start all services.
+1. **Prerequisites:** Docker and Docker Compose.
+2. **Environment Variables:**
+   ```bash
+   cp .env.example .env
+   ```
+3. **Build and Run:**
+   ```bash
+   make up
+   ```
+   This starts Server A, Server B, Redis, RabbitMQ and PostgreSQL.
 
 ## Makefile Targets
 
-*   `build`: Builds the Docker images.
-*   `up`: Starts the Docker Compose services in detached mode.
-*   `down`: Stops and removes the Docker Compose services and volumes.
-*   `logs`: Follows the logs of the `server-a` service.
-*   `lint`: Runs linting checks on `server-a`.
-*   `fmt`: Formats the code for `server-a`.
-*   `test`: Runs tests for `server-a`.
-
-## Adding Server B & Frontend
-
-*   **Server B:** To implement Server B, create a new directory `server-b/app` and add your Python/FastAPI application logic there. Update `docker-compose.yml` to include Server B as a service.
-*   **Frontend:** To implement the Frontend, create your web application files in the `frontend/` directory. You may need to add a new service to `docker-compose.yml` if it requires a build step or a specific server.
+* `build`: Builds Docker images.
+* `up`: Starts services in detached mode.
+* `down`: Stops and removes services.
+* `logs`: Follows Server A logs.
+* `logs-b`: Follows Server B logs.
+* `lint`: Lints Server A.
+* `fmt`: Formats Server A.
+* `test`: Runs Server A tests.
+* `test-b`: Runs Server B tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,17 +39,35 @@ services:
       timeout: 5s
       retries: 5
 
-  # Placeholders for future services
-  server-b:
-    image: alpine/git
-    command: ["sh", "-c", "echo 'Server B placeholder' && sleep infinity"]
-    volumes:
-      - ./server-b:/app
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: smsgw
+    ports:
+      - "5432:5432"
     healthcheck:
-      test: ["CMD", "echo", "Server B is a placeholder"]
-      interval: 30s
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
       timeout: 5s
-      retries: 3
+      retries: 5
+
+  server-b:
+    build:
+      context: ./server-b
+      dockerfile: Dockerfile
+    env_file:
+      - ./.env
+    ports:
+      - "${SERVER_B_PORT:-9000}:${SERVER_B_PORT:-9000}"
+    depends_on:
+      - rabbitmq
+      - postgres
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${SERVER_B_PORT:-9000}/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   frontend:
     image: alpine/git

--- a/server-b/Dockerfile
+++ b/server-b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir fastapi uvicorn[standard] aio-pika sqlalchemy[asyncio] asyncpg alembic httpx prometheus-client python-json-logger
+
+COPY app ./app
+COPY migrations ./migrations
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "${SERVER_B_PORT:-9000}"]

--- a/server-b/README.md
+++ b/server-b/README.md
@@ -1,0 +1,3 @@
+# Server B
+
+Processing backend for SMS Gateway. Consumes messages from RabbitMQ, applies provider policies, sends SMS via provider adapters, exposes webhook and status endpoints, and tracks metrics.

--- a/server-b/app/__init__.py
+++ b/server-b/app/__init__.py
@@ -1,0 +1,1 @@
+# Server B package

--- a/server-b/app/config.py
+++ b/server-b/app/config.py
@@ -1,0 +1,28 @@
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    service_name: str = Field("server-b", env="SERVICE_NAME")
+    host: str = Field("0.0.0.0", env="SERVER_B_HOST")
+    port: int = Field(9000, env="SERVER_B_PORT")
+
+    rabbitmq_url: str = Field("amqp://guest:guest@rabbitmq:5672/", env="RABBITMQ_URL")
+    rabbitmq_queue_outbound: str = Field("sms.outbound", env="RABBITMQ_QUEUE_OUTBOUND")
+    rabbitmq_queue_heartbeat: str = Field("a.heartbeat", env="RABBITMQ_QUEUE_HEARTBEAT")
+    rabbitmq_prefetch: int = Field(32, env="RABBITMQ_PREFETCH")
+
+    database_url: str = Field(..., env="DATABASE_URL")
+
+    max_send_attempts: int = Field(10, env="MAX_SEND_ATTEMPTS")
+    default_ttl_seconds: int = Field(3600, env="DEFAULT_TTL_SECONDS")
+    min_ttl_seconds: int = Field(10, env="MIN_TTL_SECONDS")
+    max_ttl_seconds: int = Field(86400, env="MAX_TTL_SECONDS")
+
+    smart_selection_strategy: str = Field("priority", env="SMART_SELECTION_STRATEGY")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/server-b/app/db.py
+++ b/server-b/app/db.py
@@ -1,0 +1,10 @@
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine, async_sessionmaker, AsyncSession
+from .config import settings
+
+engine: AsyncEngine = create_async_engine(settings.database_url, echo=False)
+async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncSession:
+    async with async_session() as session:
+        yield session

--- a/server-b/app/heartbeat_consumer.py
+++ b/server-b/app/heartbeat_consumer.py
@@ -1,0 +1,11 @@
+import json
+from .metrics import server_a_heartbeat_last_ts
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def process_heartbeat(body: bytes) -> None:
+    data = json.loads(body)
+    server_a_heartbeat_last_ts.set_to_current_time()
+    logger.info("heartbeat", extra=data)

--- a/server-b/app/logging.py
+++ b/server-b/app/logging.py
@@ -1,0 +1,14 @@
+import logging
+from pythonjsonlogger import jsonlogger
+
+
+def configure_logging() -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(jsonlogger.JsonFormatter())
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)

--- a/server-b/app/main.py
+++ b/server-b/app/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
+from .config import settings
+from .logging import configure_logging
+from .status_api import router as status_router
+from .webhooks import router as webhook_router
+
+app = FastAPI(title=settings.service_name)
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    configure_logging()
+
+
+@app.get("/metrics")
+async def metrics_endpoint() -> PlainTextResponse:
+    return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+app.include_router(status_router)
+app.include_router(webhook_router)

--- a/server-b/app/metrics.py
+++ b/server-b/app/metrics.py
@@ -1,0 +1,6 @@
+from prometheus_client import Counter, Gauge
+
+sms_sent_total = Counter("sms_sent_total", "Total SMS successfully sent")
+sms_failed_total = Counter("sms_failed_total", "Total SMS failed permanently")
+sms_retry_scheduled_total = Counter("sms_retry_scheduled_total", "Total SMS scheduled for retry")
+server_a_heartbeat_last_ts = Gauge("server_a_heartbeat_last_ts", "Last heartbeat timestamp from server A")

--- a/server-b/app/models.py
+++ b/server-b/app/models.py
@@ -1,0 +1,56 @@
+import enum
+import uuid
+from datetime import datetime
+from sqlalchemy import String, Integer, Enum, DateTime, ForeignKey, JSON
+from sqlalchemy.orm import declarative_base, relationship, Mapped, mapped_column
+
+Base = declarative_base()
+
+
+class MessageStatus(str, enum.Enum):
+    QUEUED = "QUEUED"
+    PROCESSING = "PROCESSING"
+    SENT = "SENT"
+    FAILED = "FAILED"
+    DELIVERED = "DELIVERED"
+
+
+class EventType(str, enum.Enum):
+    PROCESSING = "PROCESSING"
+    SENT = "SENT"
+    FAILED = "FAILED"
+    DELIVERED = "DELIVERED"
+    PROVIDER_SWITCHED = "PROVIDER_SWITCHED"
+    RETRY_SCHEDULED = "RETRY_SCHEDULED"
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    tracking_id: Mapped[str] = mapped_column(String, unique=True, default=lambda: str(uuid.uuid4()))
+    client_key: Mapped[str] = mapped_column(String)
+    to: Mapped[str] = mapped_column(String)
+    text: Mapped[str] = mapped_column(String)
+    ttl_seconds: Mapped[int] = mapped_column(Integer)
+    provider_final: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[MessageStatus] = mapped_column(Enum(MessageStatus), default=MessageStatus.QUEUED)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    events: Mapped[list["MessageEvent"]] = relationship(
+        "MessageEvent", back_populates="message", cascade="all, delete-orphan"
+    )
+
+
+class MessageEvent(Base):
+    __tablename__ = "message_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    tracking_id: Mapped[str] = mapped_column(String, ForeignKey("messages.tracking_id"))
+    event_type: Mapped[EventType] = mapped_column(Enum(EventType))
+    provider: Mapped[str | None] = mapped_column(String, nullable=True)
+    details: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    message: Mapped[Message] = relationship("Message", back_populates="events")

--- a/server-b/app/policy_engine.py
+++ b/server-b/app/policy_engine.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import List
+from .utils import is_expired
+
+
+class PolicyError(Exception):
+    pass
+
+
+def select_providers(
+    *,
+    providers: List[str],
+    policy: str,
+    registry,
+    created_at: datetime,
+    ttl_seconds: int,
+    send_attempts: int,
+    strategy: str = "priority",
+    now: datetime | None = None,
+) -> List[str]:
+    if is_expired(created_at, ttl_seconds, now):
+        raise PolicyError("message expired")
+
+    active = [p for p in providers if registry.is_enabled(p)]
+
+    if policy == "exclusive":
+        if not active:
+            raise PolicyError("exclusive provider disabled")
+        return [active[0]]
+
+    if policy == "prioritized":
+        if not active:
+            raise PolicyError("no providers available")
+        return active
+
+    if policy == "smart":
+        if not active:
+            raise PolicyError("no providers available")
+        if strategy == "round_robin":
+            idx = send_attempts % len(active)
+            return active[idx:] + active[:idx]
+        return active
+
+    raise PolicyError("unknown policy")

--- a/server-b/app/provider_registry.py
+++ b/server-b/app/provider_registry.py
@@ -1,0 +1,21 @@
+from typing import Dict, Type
+from .providers.base import BaseProvider
+
+
+class ProviderRegistry:
+    def __init__(self):
+        self._providers: Dict[str, BaseProvider] = {}
+        self._enabled: Dict[str, bool] = {}
+
+    def register(self, name: str, provider: BaseProvider, enabled: bool = True) -> None:
+        self._providers[name] = provider
+        self._enabled[name] = enabled
+
+    def get(self, name: str) -> BaseProvider:
+        return self._providers[name]
+
+    def is_enabled(self, name: str) -> bool:
+        return self._enabled.get(name, False)
+
+    def names(self) -> list[str]:
+        return list(self._providers.keys())

--- a/server-b/app/providers/__init__.py
+++ b/server-b/app/providers/__init__.py
@@ -1,0 +1,4 @@
+from .provider_a import ProviderA
+from .local_sms import LocalSMS
+
+__all__ = ["ProviderA", "LocalSMS"]

--- a/server-b/app/providers/base.py
+++ b/server-b/app/providers/base.py
@@ -1,0 +1,21 @@
+import enum
+from dataclasses import dataclass
+
+
+class SendStatus(enum.Enum):
+    SUCCESS = "success"
+    TEMP_FAILURE = "temp_failure"
+    PERM_FAILURE = "perm_failure"
+
+
+@dataclass
+class SendResult:
+    status: SendStatus
+    details: dict | None = None
+
+
+class BaseProvider:
+    name: str
+
+    async def send_sms(self, to: str, text: str) -> SendResult:  # pragma: no cover - interface
+        raise NotImplementedError

--- a/server-b/app/providers/local_sms.py
+++ b/server-b/app/providers/local_sms.py
@@ -1,0 +1,8 @@
+from .base import BaseProvider, SendResult, SendStatus
+
+
+class LocalSMS(BaseProvider):
+    name = "local_sms"
+
+    async def send_sms(self, to: str, text: str) -> SendResult:
+        return SendResult(SendStatus.SUCCESS, {"echo": text})

--- a/server-b/app/providers/provider_a.py
+++ b/server-b/app/providers/provider_a.py
@@ -1,0 +1,17 @@
+import httpx
+from .base import BaseProvider, SendResult, SendStatus
+
+
+class ProviderA(BaseProvider):
+    name = "provider_a"
+
+    def __init__(self, client: httpx.AsyncClient | None = None):
+        self.client = client or httpx.AsyncClient()
+
+    async def send_sms(self, to: str, text: str) -> SendResult:
+        resp = await self.client.post("https://provider-a.example/send", json={"to": to, "text": text})
+        if resp.status_code == 200:
+            return SendResult(SendStatus.SUCCESS, resp.json())
+        if resp.status_code >= 500:
+            return SendResult(SendStatus.TEMP_FAILURE, {"status_code": resp.status_code})
+        return SendResult(SendStatus.PERM_FAILURE, {"status_code": resp.status_code})

--- a/server-b/app/rabbit_consumer.py
+++ b/server-b/app/rabbit_consumer.py
@@ -1,0 +1,47 @@
+from . import policy_engine, models, metrics, utils
+from .repositories import MessageRepository
+from .provider_registry import ProviderRegistry
+from .providers.base import SendStatus
+from .schemas import MessageIn
+
+
+async def process_message(
+    message: MessageIn,
+    repo: MessageRepository,
+    registry: ProviderRegistry,
+    strategy: str,
+) -> dict:
+    providers = policy_engine.select_providers(
+        providers=message.providers,
+        policy=message.policy,
+        registry=registry,
+        created_at=message.created_at,
+        ttl_seconds=message.ttl_seconds,
+        send_attempts=message.send_attempts,
+        strategy=strategy,
+    )
+
+    for name in providers:
+        provider = registry.get(name)
+        await repo.add_event(message.tracking_id, models.EventType.PROCESSING, name)
+        result = await provider.send_sms(message.to, message.text)
+        if result.status == SendStatus.SUCCESS:
+            await repo.update_message_status(message.tracking_id, models.MessageStatus.SENT, name)
+            await repo.add_event(message.tracking_id, models.EventType.SENT, name, result.details)
+            metrics.sms_sent_total.inc()
+            return {"status": "sent"}
+        if result.status == SendStatus.TEMP_FAILURE:
+            await repo.add_event(message.tracking_id, models.EventType.FAILED, name, result.details)
+            await repo.add_event(
+                message.tracking_id,
+                models.EventType.RETRY_SCHEDULED,
+                name,
+                {"attempt": message.send_attempts + 1},
+            )
+            metrics.sms_retry_scheduled_total.inc()
+            delay = utils.compute_backoff(message.send_attempts + 1)
+            return {"status": "retry", "delay": delay}
+        await repo.add_event(message.tracking_id, models.EventType.FAILED, name, result.details)
+        metrics.sms_failed_total.inc()
+    await repo.update_message_status(message.tracking_id, models.MessageStatus.FAILED)
+    return {"status": "failed"}

--- a/server-b/app/repositories.py
+++ b/server-b/app/repositories.py
@@ -1,0 +1,38 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, update
+from sqlalchemy.orm import selectinload
+from . import models
+
+
+class MessageRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create_message(self, data: models.Message) -> None:
+        self.session.add(data)
+        await self.session.commit()
+
+    async def update_message_status(self, tracking_id: str, status: models.MessageStatus, provider_final: str | None = None) -> None:
+        await self.session.execute(
+            update(models.Message)
+            .where(models.Message.tracking_id == tracking_id)
+            .values(status=status, provider_final=provider_final)
+        )
+        await self.session.commit()
+
+    async def add_event(
+        self, tracking_id: str, event_type: models.EventType, provider: str | None = None, details: dict | None = None
+    ) -> None:
+        evt = models.MessageEvent(
+            tracking_id=tracking_id, event_type=event_type, provider=provider, details=details or {}
+        )
+        self.session.add(evt)
+        await self.session.commit()
+
+    async def get_message_with_events(self, tracking_id: str) -> models.Message | None:
+        result = await self.session.execute(
+            select(models.Message).where(models.Message.tracking_id == tracking_id).options(
+                selectinload(models.Message.events)
+            )
+        )
+        return result.scalars().first()

--- a/server-b/app/schemas.py
+++ b/server-b/app/schemas.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class MessageIn(BaseModel):
+    tracking_id: str
+    client_key: str
+    to: str
+    text: str
+    providers: List[str] = Field(default_factory=list)
+    policy: str = "prioritized"
+    send_attempts: int = 0
+    ttl_seconds: int = 3600
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class MessageStatusOut(BaseModel):
+    tracking_id: str
+    status: str
+    provider_final: Optional[str]
+    to: str
+    text: str
+
+
+class EventOut(BaseModel):
+    event_type: str
+    provider: Optional[str]
+    details: dict
+    created_at: datetime
+
+
+class MessageWithEventsOut(MessageStatusOut):
+    events: List[EventOut]

--- a/server-b/app/status_api.py
+++ b/server-b/app/status_api.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from .db import get_session
+from .repositories import MessageRepository
+from . import models, schemas
+
+router = APIRouter()
+
+
+@router.get("/messages/{tracking_id}", response_model=schemas.MessageWithEventsOut)
+async def get_message(tracking_id: str, session: AsyncSession = Depends(get_session)):
+    repo = MessageRepository(session)
+    msg = await repo.get_message_with_events(tracking_id)
+    if not msg:
+        raise HTTPException(status_code=404, detail="not found")
+    events = [
+        schemas.EventOut(
+            event_type=e.event_type.value,
+            provider=e.provider,
+            details=e.details,
+            created_at=e.created_at,
+        )
+        for e in sorted(msg.events, key=lambda x: x.created_at)
+    ]
+    return schemas.MessageWithEventsOut(
+        tracking_id=msg.tracking_id,
+        status=msg.status.value,
+        provider_final=msg.provider_final,
+        to=msg.to,
+        text=msg.text,
+        events=events,
+    )

--- a/server-b/app/utils.py
+++ b/server-b/app/utils.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timedelta
+
+
+def is_expired(created_at: datetime, ttl_seconds: int, now: datetime | None = None) -> bool:
+    now = now or datetime.utcnow()
+    return created_at + timedelta(seconds=ttl_seconds) < now
+
+
+def compute_backoff(attempt: int) -> int:
+    """Simple exponential backoff in seconds."""
+    return 2 ** attempt

--- a/server-b/app/webhooks.py
+++ b/server-b/app/webhooks.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+from .db import get_session
+from .repositories import MessageRepository
+from . import models
+
+router = APIRouter()
+
+
+class DeliveryUpdate(BaseModel):
+    tracking_id: str
+
+
+@router.post("/webhook/{provider}")
+async def handle_webhook(provider: str, payload: DeliveryUpdate, session: AsyncSession = Depends(get_session)):
+    repo = MessageRepository(session)
+    await repo.update_message_status(payload.tracking_id, models.MessageStatus.DELIVERED, provider)
+    await repo.add_event(payload.tracking_id, models.EventType.DELIVERED, provider, {})
+    return {"status": "ok"}

--- a/server-b/migrations/env.py
+++ b/server-b/migrations/env.py
@@ -1,0 +1,42 @@
+import asyncio
+from logging.config import fileConfig
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import create_async_engine
+from alembic import context
+from app import models
+from app.config import settings
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = settings.database_url
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"}
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = create_async_engine(settings.database_url, poolclass=pool.NullPool)
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/server-b/migrations/versions/202405070001_initial.py
+++ b/server-b/migrations/versions/202405070001_initial.py
@@ -1,0 +1,45 @@
+"""initial
+
+Revision ID: 202405070001
+Revises: 
+Create Date: 2024-05-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "202405070001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("tracking_id", sa.String, unique=True),
+        sa.Column("client_key", sa.String),
+        sa.Column("to", sa.String),
+        sa.Column("text", sa.String),
+        sa.Column("ttl_seconds", sa.Integer),
+        sa.Column("provider_final", sa.String, nullable=True),
+        sa.Column("status", sa.String),
+        sa.Column("created_at", sa.DateTime),
+        sa.Column("updated_at", sa.DateTime),
+    )
+    op.create_table(
+        "message_events",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("tracking_id", sa.String, sa.ForeignKey("messages.tracking_id")),
+        sa.Column("event_type", sa.String),
+        sa.Column("provider", sa.String, nullable=True),
+        sa.Column("details", sa.JSON),
+        sa.Column("created_at", sa.DateTime),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("message_events")
+    op.drop_table("messages")

--- a/server-b/pyproject.toml
+++ b/server-b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "server-b"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "aio-pika",
+    "sqlalchemy[asyncio]",
+    "asyncpg",
+    "alembic",
+    "httpx",
+    "prometheus-client",
+    "python-json-logger",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "httpx",
+]

--- a/server-b/tests/conftest.py
+++ b/server-b/tests/conftest.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+import httpx
+from app.main import app
+from app import models
+from app.db import get_session
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+async def async_sessionmaker_fixture():
+    os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
+    engine = create_async_engine(os.environ["DATABASE_URL"])
+    async with engine.begin() as conn:
+        await conn.run_sync(models.Base.metadata.create_all)
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def override_get_session(async_sessionmaker_fixture):
+    async def _get_session():
+        async with async_sessionmaker_fixture() as session:
+            yield session
+    app.dependency_overrides[get_session] = _get_session
+
+
+@pytest.fixture()
+async def session(async_sessionmaker_fixture):
+    async with async_sessionmaker_fixture() as s:
+        yield s
+
+
+@pytest.fixture()
+async def client():
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac

--- a/server-b/tests/test_consumer_flow.py
+++ b/server-b/tests/test_consumer_flow.py
@@ -1,0 +1,89 @@
+import pytest
+from app import models
+from app.repositories import MessageRepository
+from app.provider_registry import ProviderRegistry
+from app.providers.base import BaseProvider, SendResult, SendStatus
+from app.schemas import MessageIn
+from app import rabbit_consumer
+
+
+class TempFailProvider(BaseProvider):
+    name = "temp"
+
+    async def send_sms(self, to: str, text: str) -> SendResult:
+        return SendResult(SendStatus.TEMP_FAILURE, {})
+
+
+class SuccessProvider(BaseProvider):
+    name = "succ"
+
+    async def send_sms(self, to: str, text: str) -> SendResult:
+        return SendResult(SendStatus.SUCCESS, {})
+
+
+class PermFailProvider(BaseProvider):
+    name = "perm"
+
+    async def send_sms(self, to: str, text: str) -> SendResult:
+        return SendResult(SendStatus.PERM_FAILURE, {})
+
+
+@pytest.mark.asyncio
+async def test_temp_failure_schedules_retry(session):
+    repo = MessageRepository(session)
+    reg = ProviderRegistry()
+    reg.register("temp", TempFailProvider())
+    message = MessageIn(
+        tracking_id="t1",
+        client_key="c",
+        to="123",
+        text="hi",
+        providers=["temp"],
+        policy="prioritized",
+    )
+    await repo.create_message(models.Message(tracking_id="t1", client_key="c", to="123", text="hi", ttl_seconds=60))
+    result = await rabbit_consumer.process_message(message, repo, reg, "priority")
+    assert result["status"] == "retry"
+
+
+@pytest.mark.asyncio
+async def test_success_updates_status(session):
+    repo = MessageRepository(session)
+    reg = ProviderRegistry()
+    reg.register("succ", SuccessProvider())
+    message = MessageIn(
+        tracking_id="t2",
+        client_key="c",
+        to="123",
+        text="hi",
+        providers=["succ"],
+        policy="prioritized",
+    )
+    await repo.create_message(models.Message(tracking_id="t2", client_key="c", to="123", text="hi", ttl_seconds=60))
+    result = await rabbit_consumer.process_message(message, repo, reg, "priority")
+    assert result["status"] == "sent"
+    msg = await repo.get_message_with_events("t2")
+    assert msg.status == models.MessageStatus.SENT
+
+
+@pytest.mark.asyncio
+async def test_perm_failure_switches_provider(session):
+    repo = MessageRepository(session)
+    reg = ProviderRegistry()
+    reg.register("perm", PermFailProvider())
+    reg.register("succ", SuccessProvider())
+    message = MessageIn(
+        tracking_id="t3",
+        client_key="c",
+        to="123",
+        text="hi",
+        providers=["perm", "succ"],
+        policy="prioritized",
+    )
+    await repo.create_message(models.Message(tracking_id="t3", client_key="c", to="123", text="hi", ttl_seconds=60))
+    result = await rabbit_consumer.process_message(message, repo, reg, "priority")
+    assert result["status"] == "sent"
+    msg = await repo.get_message_with_events("t3")
+    assert msg.provider_final == "succ"
+    fail_events = [e for e in msg.events if e.event_type == models.EventType.FAILED]
+    assert any(e.provider == "perm" for e in fail_events)

--- a/server-b/tests/test_policy_engine.py
+++ b/server-b/tests/test_policy_engine.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timedelta
+import pytest
+from app import policy_engine
+from app.provider_registry import ProviderRegistry
+from app.providers.local_sms import LocalSMS
+
+
+def make_registry(enabled: dict[str, bool]) -> ProviderRegistry:
+    reg = ProviderRegistry()
+    for name, is_enabled in enabled.items():
+        reg.register(name, LocalSMS(), enabled=is_enabled)
+    return reg
+
+
+def test_exclusive_disabled():
+    reg = make_registry({"p1": False})
+    with pytest.raises(policy_engine.PolicyError):
+        policy_engine.select_providers(
+            providers=["p1"],
+            policy="exclusive",
+            registry=reg,
+            created_at=datetime.utcnow(),
+            ttl_seconds=60,
+            send_attempts=0,
+        )
+
+
+def test_prioritized_skip_and_fail_empty():
+    reg = make_registry({"a": True, "b": False})
+    providers = policy_engine.select_providers(
+        providers=["a", "b"],
+        policy="prioritized",
+        registry=reg,
+        created_at=datetime.utcnow(),
+        ttl_seconds=60,
+        send_attempts=0,
+    )
+    assert providers == ["a"]
+
+    reg2 = make_registry({"a": False})
+    with pytest.raises(policy_engine.PolicyError):
+        policy_engine.select_providers(
+            providers=["a"],
+            policy="prioritized",
+            registry=reg2,
+            created_at=datetime.utcnow(),
+            ttl_seconds=60,
+            send_attempts=0,
+        )
+
+
+def test_smart_selection_priority_and_round_robin():
+    reg = make_registry({"a": True, "b": True})
+    msg_created = datetime.utcnow()
+    providers_priority = policy_engine.select_providers(
+        providers=["a", "b"],
+        policy="smart",
+        registry=reg,
+        created_at=msg_created,
+        ttl_seconds=60,
+        send_attempts=0,
+        strategy="priority",
+    )
+    assert providers_priority == ["a", "b"]
+
+    providers_rr = policy_engine.select_providers(
+        providers=["a", "b"],
+        policy="smart",
+        registry=reg,
+        created_at=msg_created,
+        ttl_seconds=60,
+        send_attempts=1,
+        strategy="round_robin",
+    )
+    assert providers_rr == ["b", "a"]
+
+
+def test_ttl_expiry():
+    reg = make_registry({"a": True})
+    past = datetime.utcnow() - timedelta(seconds=120)
+    with pytest.raises(policy_engine.PolicyError):
+        policy_engine.select_providers(
+            providers=["a"],
+            policy="prioritized",
+            registry=reg,
+            created_at=past,
+            ttl_seconds=60,
+            send_attempts=0,
+        )

--- a/server-b/tests/test_status_api.py
+++ b/server-b/tests/test_status_api.py
@@ -1,0 +1,18 @@
+import pytest
+from app.repositories import MessageRepository
+from app import models
+
+
+@pytest.mark.asyncio
+async def test_status_api_returns_events_ordered(client, session):
+    repo = MessageRepository(session)
+    await repo.create_message(
+        models.Message(tracking_id="s1", client_key="c", to="123", text="hi", ttl_seconds=60)
+    )
+    await repo.add_event("s1", models.EventType.PROCESSING, "p1")
+    await repo.add_event("s1", models.EventType.SENT, "p1")
+    resp = await client.get("/messages/s1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tracking_id"] == "s1"
+    assert [e["event_type"] for e in data["events"]] == ["PROCESSING", "SENT"]

--- a/server-b/tests/test_webhooks.py
+++ b/server-b/tests/test_webhooks.py
@@ -1,0 +1,16 @@
+import pytest
+from app.repositories import MessageRepository
+from app import models
+
+
+@pytest.mark.asyncio
+async def test_webhook_marks_delivered(client, session):
+    repo = MessageRepository(session)
+    await repo.create_message(
+        models.Message(tracking_id="w1", client_key="c", to="123", text="hi", ttl_seconds=60, status=models.MessageStatus.SENT)
+    )
+    resp = await client.post("/webhook/provider_a", json={"tracking_id": "w1"})
+    assert resp.status_code == 200
+    msg = await repo.get_message_with_events("w1")
+    assert msg.status == models.MessageStatus.DELIVERED
+    assert any(e.event_type == models.EventType.DELIVERED for e in msg.events)


### PR DESCRIPTION
## Summary
- implement Server B backend with policy engine, providers, database models and API routers
- add migrations, Dockerfile and tests for core flows
- extend compose, env and repository docs for Server B and Postgres

## Testing
- `PYTHONPATH=server-b pytest server-b/tests/test_policy_engine.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68a8639ecbc48320b1e79c1696618b6c