### PR TITLE
Add separate test workflows for servers A and B

### DIFF
--- a/.github/workflows/server-a-tests.yml
+++ b/.github/workflows/server-a-tests.yml
@@ -1,0 +1,33 @@
+name: Server A Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      CLIENT_CONFIG: '{"test_client": {"name": "Test Client", "is_active": true, "daily_quota": 1000}}'
+      PROVIDERS_CONFIG: '{"test_provider": {"is_active": true, "is_operational": true}}'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      working-directory: server-a
+      run: pip install -r requirements.txt
+
+    - name: Run tests
+      working-directory: server-a
+      run: pytest

--- a/.github/workflows/server-b-tests.yml
+++ b/.github/workflows/server-b-tests.yml
@@ -1,4 +1,4 @@
-name: Python Tests
+name: Server B Tests
 
 on:
   push:
@@ -11,9 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      CLIENT_CONFIG: '{"test_client": {"name": "Test Client", "is_active": true, "daily_quota": 1000}}'
-      PROVIDERS_CONFIG: '{"test_provider": {"is_active": true, "is_operational": true}}'
 
     steps:
     - name: Checkout code
@@ -25,9 +22,9 @@ jobs:
         python-version: '3.12'
 
     - name: Install dependencies
-      working-directory: server-a
-      run: pip install -r requirements.txt
+      working-directory: server-b
+      run: pip install .[test]
 
     - name: Run tests
-      working-directory: server-a
+      working-directory: server-b
       run: pytest


### PR DESCRIPTION
## Summary
- rename Python test workflow to `Server A Tests`
- add dedicated `Server B Tests` workflow using plain `pytest`

## Testing
- `CLIENT_CONFIG='{"test_client": {"name": "Test Client", "is_active": true, "daily_quota": 1000}}' PROVIDERS_CONFIG='{"test_provider": {"is_active": true, "is_operational": true}}' pytest`
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_b_68a8660098408320bf25a92d88ed5833