### PR TITLE
Add server-b requirements and adjust workflow

### DIFF
--- a/.github/workflows/server-b-tests.yml
+++ b/.github/workflows/server-b-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: server-b
-      run: pip install .[test]
+      run: pip install -r requirements.txt
 
     - name: Run tests
       working-directory: server-b

--- a/server-b/app/config.py
+++ b/server-b/app/config.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -20,9 +21,7 @@ class Settings(BaseSettings):
 
     smart_selection_strategy: str = Field("priority", env="SMART_SELECTION_STRATEGY")
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 
 settings = Settings()

--- a/server-b/requirements.txt
+++ b/server-b/requirements.txt
@@ -1,0 +1,15 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+aio-pika==9.0.7
+sqlalchemy[asyncio]==2.0.30
+asyncpg==0.29.0
+alembic==1.13.1
+httpx==0.27.0
+prometheus-client==0.20.0
+python-json-logger==2.0.7
+pydantic==2.7.4
+pydantic-settings==2.3.3
+python-dotenv==1.0.0
+pytest==8.2.2
+pytest-asyncio==0.23.7
+


### PR DESCRIPTION
## Summary
- add explicit requirements.txt for server-b
- update config to use pydantic-settings
- install dependencies from requirements in server-b workflow

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy==2.0.30)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68a867f989508320bf82a705872bb48a