### PR TITLE
Fix server-b test import path

### DIFF
--- a/server-b/tests/conftest.py
+++ b/server-b/tests/conftest.py
@@ -1,8 +1,16 @@
 import asyncio
 import os
+import sys
+from pathlib import Path
+
 import pytest
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 import httpx
+
+# Ensure that the application package is importable when tests are executed
+# from the repository root by adding the "server-b" directory to ``sys.path``.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from app.main import app
 from app import models
 from app.db import get_session


### PR DESCRIPTION
## Summary
- ensure server-b tests can import the app package by appending server-b to `sys.path`

## Testing
- `pip install -r server-b/requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy==2.0.30)*
- `pytest server-b/tests/test_policy_engine.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_b_68a869f394c88320b06c25a39c52e97a