### PR TITLE
fix: expand SERVER_B_PORT in server-b Dockerfile

### DIFF
--- a/server-b/Dockerfile
+++ b/server-b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir fastapi uvicorn[standard] aio-pika sqlalchemy[asy
 COPY app ./app
 COPY migrations ./migrations
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "${SERVER_B_PORT:-9000}"]
+CMD uvicorn app.main:app --host 0.0.0.0 --port ${SERVER_B_PORT:-9000}


### PR DESCRIPTION
## Summary
- ensure server-b Dockerfile expands SERVER_B_PORT by using shell-form CMD

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a88112b1348320b39c13a224d962a0