### PR TITLE
Fix missing pydantic settings dependency in server-b Dockerfile

### DIFF
--- a/server-b/Dockerfile
+++ b/server-b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY pyproject.toml ./
-RUN pip install --no-cache-dir fastapi uvicorn[standard] aio-pika sqlalchemy[asyncio] asyncpg alembic httpx prometheus-client python-json-logger
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
 COPY migrations ./migrations

--- a/server-b/pyproject.toml
+++ b/server-b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "httpx",
     "prometheus-client",
     "python-json-logger",
+    "pydantic",
+    "pydantic-settings",
+    "python-dotenv",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- install Python dependencies from requirements.txt when building server-b image
- declare pydantic, pydantic-settings, and python-dotenv in server-b's pyproject

## Testing
- `pytest server-b/tests`

------
https://chatgpt.com/codex/tasks/task_b_68a882a1b8d08320a29d36fd3b218310