### PR TITLE
feat: add configurable CORS support

### DIFF
--- a/server-b/.env.example
+++ b/server-b/.env.example
@@ -1,0 +1,1 @@
+ALLOWED_ORIGINS=http://localhost:5173

--- a/server-b/README.md
+++ b/server-b/README.md
@@ -1,3 +1,12 @@
 # Server B
 
 Processing backend for SMS Gateway. Consumes messages from RabbitMQ, applies provider policies, sends SMS via provider adapters, exposes webhook and status endpoints, and tracks metrics.
+
+## Configuration
+
+Set the `ALLOWED_ORIGINS` environment variable in a `.env` file to specify which web origins are permitted to access the API.
+The value should be a comma-separated list of origins, for example:
+
+```
+ALLOWED_ORIGINS=http://localhost:5173
+```

--- a/server-b/app/config.py
+++ b/server-b/app/config.py
@@ -14,6 +14,8 @@ class Settings(BaseSettings):
 
     database_url: str = Field(..., env="DATABASE_URL")
 
+    allowed_origins: list[str] = Field(default_factory=list, env="ALLOWED_ORIGINS")
+
     max_send_attempts: int = Field(10, env="MAX_SEND_ATTEMPTS")
     default_ttl_seconds: int = Field(3600, env="DEFAULT_TTL_SECONDS")
     min_ttl_seconds: int = Field(10, env="MIN_TTL_SECONDS")

--- a/server-b/app/main.py
+++ b/server-b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from .config import settings
@@ -7,6 +8,14 @@ from .status_api import router as status_router
 from .webhooks import router as webhook_router
 
 app = FastAPI(title=settings.service_name)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- allow configuring trusted origins for server-b via `ALLOWED_ORIGINS` env var
- enable FastAPI `CORSMiddleware` with configured origins
- document new setting and provide `.env.example`

## Testing
- `pytest server-b/tests`


------
https://chatgpt.com/codex/tasks/task_b_68a89c7174588320867f31fe482cc47c