### PR TITLE
Add basic login endpoint to server-b

### DIFF
--- a/server-b/app/auth.py
+++ b/server-b/app/auth.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/auth")
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+@router.post("/login")
+async def login(payload: LoginRequest):
+    if payload.username == "admin" and payload.password == "changeme":
+        return {"message": "Login successful"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")

--- a/server-b/app/main.py
+++ b/server-b/app/main.py
@@ -6,6 +6,7 @@ from .config import settings
 from .logging import configure_logging
 from .status_api import router as status_router
 from .webhooks import router as webhook_router
+from .auth import router as auth_router
 
 app = FastAPI(title=settings.service_name)
 
@@ -30,3 +31,4 @@ async def metrics_endpoint() -> PlainTextResponse:
 
 app.include_router(status_router)
 app.include_router(webhook_router)
+app.include_router(auth_router)

--- a/server-b/tests/test_auth.py
+++ b/server-b/tests/test_auth.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_login_success(client):
+    resp = await client.post("/api/auth/login", json={"username": "admin", "password": "changeme"})
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Login successful"}
+
+
+@pytest.mark.asyncio
+async def test_login_failure(client):
+    resp = await client.post("/api/auth/login", json={"username": "admin", "password": "wrong"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"


### PR DESCRIPTION
## Summary
- add FastAPI auth router with `/api/auth/login` endpoint and hardcoded credentials
- wire router into application
- test login success and failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a89fefb7388320ae7cafb6f23edfb0