### PR TITLE
feat(frontend): add protected routes and standalone login

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import Router from './router';
-import { AppShell } from './components/layout/AppShell';
 import { AuthProvider } from './hooks/useAuth';
 
 export default function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
-        <AppShell>
-          <Router />
-        </AppShell>
+        <Router />
       </BrowserRouter>
     </AuthProvider>
   );

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { AppShell } from './layout/AppShell';
+
+export const ProtectedRoute: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  return <AppShell>{children}</AppShell>;
+};

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Input } from '../components/ui/Input';
 import { Button } from '../components/ui/Button';
 import { useAuth } from '../hooks/useAuth';
 
 export default function Login() {
   const { login } = useAuth();
+  const navigate = useNavigate();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -13,6 +15,7 @@ export default function Login() {
     e.preventDefault();
     try {
       await login(username, password);
+      navigate('/dashboard');
     } catch (err: any) {
       setError(err.message);
     }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,18 +6,52 @@ import MessagesList from './pages/MessagesList';
 import MessageDetail from './pages/MessageDetail';
 import UsersAdmin from './pages/UsersAdmin';
 import NotFound from './pages/NotFound';
-import { useAuth } from './hooks/useAuth';
+import { ProtectedRoute } from './components/ProtectedRoute';
 
 export default function Router() {
-  const { isAuthenticated } = useAuth();
   return (
     <Routes>
-      <Route path="/" element={isAuthenticated ? <Dashboard /> : <Login />} />
       <Route path="/login" element={<Login />} />
-      <Route path="/dashboard" element={<Dashboard />} />
-      <Route path="/messages" element={<MessagesList />} />
-      <Route path="/messages/:id" element={<MessageDetail />} />
-      <Route path="/users" element={<UsersAdmin />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <Dashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dashboard"
+        element={
+          <ProtectedRoute>
+            <Dashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/messages"
+        element={
+          <ProtectedRoute>
+            <MessagesList />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/messages/:id"
+        element={
+          <ProtectedRoute>
+            <MessageDetail />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/users"
+        element={
+          <ProtectedRoute>
+            <UsersAdmin />
+          </ProtectedRoute>
+        }
+      />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );


### PR DESCRIPTION
## Summary
- isolate login page by removing global AppShell wrapper
- add ProtectedRoute to show menu only after authentication
- redirect users to dashboard after successful login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8a3375e50832083c29bbe61a72679