### PR TITLE
Return token on successful login

### DIFF
--- a/server-b/app/auth.py
+++ b/server-b/app/auth.py
@@ -12,5 +12,9 @@ class LoginRequest(BaseModel):
 @router.post("/login")
 async def login(payload: LoginRequest):
     if payload.username == "admin" and payload.password == "changeme":
-        return {"message": "Login successful"}
+        # In a real application this would return a JWT or session token.
+        # Returning a static token keeps the example simple while allowing
+        # the frontend to store something and treat the user as authenticated.
+        return {"access_token": "fake-token", "token_type": "bearer"}
+
     raise HTTPException(status_code=401, detail="Invalid credentials")

--- a/server-b/tests/test_auth.py
+++ b/server-b/tests/test_auth.py
@@ -5,7 +5,7 @@ import pytest
 async def test_login_success(client):
     resp = await client.post("/api/auth/login", json={"username": "admin", "password": "changeme"})
     assert resp.status_code == 200
-    assert resp.json() == {"message": "Login successful"}
+    assert resp.json() == {"access_token": "fake-token", "token_type": "bearer"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- return a dummy access token on successful login
- adjust auth tests to expect token response

## Testing
- `pytest server-a/tests`
- `pytest server-b/tests`


------
https://chatgpt.com/codex/tasks/task_b_68a8a512ea008320b85496b7e97a6b8b