### PR TITLE
feat: implement login page design

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Input } from '../components/ui/Input';
-import { Button } from '../components/ui/Button';
 import { useAuth } from '../hooks/useAuth';
 
 export default function Login() {
@@ -22,22 +20,67 @@ export default function Login() {
   };
 
   return (
-    <div className="max-w-sm mx-auto mt-20">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {error && <div className="text-red-600">{error}</div>}
-        <Input
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <Input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button type="submit">Login</Button>
-      </form>
+    <div className="relative flex min-h-screen flex-col bg-white overflow-x-hidden">
+      <div className="flex h-full grow flex-col">
+        <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f0f2f5] px-10 py-3">
+          <div className="flex items-center gap-4 text-[#111418]">
+            <div className="size-4">
+              <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M24 45.8096C19.6865 45.8096 15.4698 44.5305 11.8832 42.134C8.29667 39.7376 5.50128 36.3314 3.85056 32.3462C2.19985 28.361 1.76794 23.9758 2.60947 19.7452C3.451 15.5145 5.52816 11.6284 8.57829 8.5783C11.6284 5.52817 15.5145 3.45101 19.7452 2.60948C23.9758 1.76795 28.361 2.19986 32.3462 3.85057C36.3314 5.50129 39.7376 8.29668 42.134 11.8833C44.5305 15.4698 45.8096 19.6865 45.8096 24L24 24L24 45.8096Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+            <h2 className="text-[#111418] text-lg font-bold leading-tight tracking-[-0.015em]">
+              SMS Gateway Admin
+            </h2>
+          </div>
+        </header>
+        <div className="px-40 flex flex-1 justify-center py-5">
+          <div className="flex flex-col w-[512px] max-w-[512px] py-5 flex-1 max-w-[960px]">
+            <h2 className="text-[#111418] tracking-light text-[28px] font-bold leading-tight px-4 text-center pb-3 pt-5">
+              Welcome back
+            </h2>
+            <form onSubmit={handleSubmit}>
+              <div className="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label className="flex flex-col min-w-40 flex-1">
+                  <input
+                    type="text"
+                    placeholder="Email"
+                    className="flex w-full flex-1 rounded-lg bg-[#f0f2f5] h-14 p-4 text-base text-[#111418] placeholder:text-[#60758a] focus:outline-none focus:ring-0"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label className="flex flex-col min-w-40 flex-1">
+                  <input
+                    type="password"
+                    placeholder="Password"
+                    className="flex w-full flex-1 rounded-lg bg-[#f0f2f5] h-14 p-4 text-base text-[#111418] placeholder:text-[#60758a] focus:outline-none focus:ring-0"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                  />
+                </label>
+              </div>
+              {error && <div className="text-red-600 px-4 -mt-2">{error}</div>}
+              <p className="text-[#60758a] text-sm font-normal leading-normal pb-3 pt-1 px-4 underline">
+                Forgot password?
+              </p>
+              <div className="flex px-4 py-3">
+                <button
+                  type="submit"
+                  className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-5 flex-1 bg-[#0d80f2] text-white text-base font-bold leading-normal tracking-[0.015em]"
+                >
+                  <span className="truncate">Log in</span>
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/test/pages/login.test.tsx
+++ b/frontend/src/test/pages/login.test.tsx
@@ -16,15 +16,15 @@ describe('Login Page', () => {
         </BrowserRouter>
       </AuthProvider>
     );
-    fireEvent.change(screen.getByPlaceholderText(/username/i), {
+    fireEvent.change(screen.getByPlaceholderText(/email/i), {
       target: { value: 'admin' },
     });
     fireEvent.change(screen.getByPlaceholderText(/password/i), {
       target: { value: 'pass' },
     });
-    fireEvent.click(screen.getByText(/login/i));
+    fireEvent.click(screen.getByText(/log in/i));
     // since login sets localStorage, check token
-    await screen.findByText(/login/i);
+    await screen.findByText(/log in/i);
     expect(localStorage.getItem('token')).toBe('mock-token');
   });
 });


### PR DESCRIPTION
## Summary
- revamp login page with full layout and styled inputs
- adjust login tests for new placeholders and button text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8a5fce08c8320984b739099adc70f