### PR TITLE
feat: add user management system

### DIFF
--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,11 +1,57 @@
 import { request } from './client';
 
 export interface User {
-  id: string;
+  id: number;
+  name: string;
   username: string;
-  role: string;
+  daily_quota: number;
+  api_key: string;
+  note?: string;
+  active: boolean;
+}
+
+export interface UserCreate {
+  name: string;
+  username: string;
+  daily_quota: number;
+  api_key: string;
+  password: string;
+  note?: string;
 }
 
 export function listUsers() {
   return request<User[]>('/api/users');
+}
+
+export function createUser(data: UserCreate) {
+  return request<User>('/api/users', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateUser(id: number, data: Partial<User>) {
+  return request<User>(`/api/users/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteUser(id: number) {
+  return request<void>(`/api/users/${id}`, { method: 'DELETE' });
+}
+
+export function activateUser(id: number) {
+  return request<User>(`/api/users/${id}/activate`, { method: 'POST' });
+}
+
+export function deactivateUser(id: number) {
+  return request<User>(`/api/users/${id}/deactivate`, { method: 'POST' });
+}
+
+export function changePassword(username: string, password: string) {
+  return request<void>(`/api/users/${username}/password`, {
+    method: 'POST',
+    body: JSON.stringify({ password }),
+  });
 }

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 
 export const Topbar = () => {
@@ -7,9 +8,14 @@ export const Topbar = () => {
     <header className="flex justify-between items-center border-b border-gray-300 px-4 py-2">
       <h1 className="text-xl">SMS Gateway</h1>
       {user && (
-        <button onClick={logout} className="text-sm underline">
-          Logout
-        </button>
+        <div className="space-x-2">
+          <Link to="/change-password" className="text-sm underline">
+            Change Password
+          </Link>
+          <button onClick={logout} className="text-sm underline">
+            Logout
+          </button>
+        </div>
       )}
     </header>
   );

--- a/frontend/src/pages/ChangePassword.tsx
+++ b/frontend/src/pages/ChangePassword.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { changePassword } from '../api/users';
+import { useAuth } from '../hooks/useAuth';
+
+export default function ChangePassword() {
+  const { user } = useAuth();
+  const [password, setPassword] = React.useState('');
+  const [message, setMessage] = React.useState('');
+
+  if (!user) return <div>Loading...</div>;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await changePassword(user, password);
+    setMessage('Password updated');
+    setPassword('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      <input
+        type="password"
+        placeholder="New Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Change Password</button>
+      {message && <div>{message}</div>}
+    </form>
+  );
+}

--- a/frontend/src/pages/UsersAdmin.tsx
+++ b/frontend/src/pages/UsersAdmin.tsx
@@ -1,12 +1,148 @@
 import React from 'react';
-import { useFetch } from '../hooks/useFetch';
-import { API_BASE_URL } from '../api/client';
-import { Table } from '../components/ui/Table';
-import { User } from '../api/users';
+import {
+  listUsers,
+  createUser,
+  deleteUser,
+  activateUser,
+  deactivateUser,
+  updateUser,
+  User,
+  UserCreate,
+} from '../api/users';
 
 export default function UsersAdmin() {
-  const { data } = useFetch<User[]>(`${API_BASE_URL}/api/users`);
-  if (!data) return <div>Loading...</div>;
-  const rows = data.map((u) => [u.id, u.username, u.role]);
-  return <Table headers={["ID", "Username", "Role"]} rows={rows} />;
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [form, setForm] = React.useState<UserCreate>({
+    name: '',
+    username: '',
+    daily_quota: 0,
+    api_key: '',
+    password: '',
+    note: '',
+  });
+  const [editingId, setEditingId] = React.useState<number | null>(null);
+  const [editForm, setEditForm] = React.useState<Partial<User>>({});
+
+  React.useEffect(() => {
+    listUsers().then(setUsers);
+  }, []);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const u = await createUser(form);
+    setUsers([...users, u]);
+    setForm({ name: '', username: '', daily_quota: 0, api_key: '', password: '', note: '' });
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteUser(id);
+    setUsers(users.filter((u) => u.id !== id));
+  };
+
+  const handleToggle = async (user: User) => {
+    const updated = user.active ? await deactivateUser(user.id) : await activateUser(user.id);
+    setUsers(users.map((u) => (u.id === user.id ? updated : u)));
+  };
+
+  const startEdit = (user: User) => {
+    setEditingId(user.id);
+    setEditForm({ ...user });
+  };
+
+  const submitEdit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editingId === null) return;
+    const updated = await updateUser(editingId, editForm);
+    setUsers(users.map((u) => (u.id === updated.id ? updated : u)));
+    setEditingId(null);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <form onSubmit={handleCreate} className="space-x-2">
+        <input
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          placeholder="Username"
+          value={form.username}
+          onChange={(e) => setForm({ ...form, username: e.target.value })}
+        />
+        <input
+          placeholder="Daily Quota"
+          type="number"
+          value={form.daily_quota}
+          onChange={(e) => setForm({ ...form, daily_quota: Number(e.target.value) })}
+        />
+        <input
+          placeholder="API Key"
+          value={form.api_key}
+          onChange={(e) => setForm({ ...form, api_key: e.target.value })}
+        />
+        <input
+          placeholder="Password"
+          type="password"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+        />
+        <input
+          placeholder="Note"
+          value={form.note || ''}
+          onChange={(e) => setForm({ ...form, note: e.target.value })}
+        />
+        <button type="submit">Add User</button>
+      </form>
+
+      <table className="w-full border">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Username</th>
+            <th>Name</th>
+            <th>Active</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id}>
+              {editingId === u.id ? (
+                <>
+                  <td>{u.id}</td>
+                  <td>{u.username}</td>
+                  <td>
+                    <input
+                      value={editForm.name || ''}
+                      onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                    />
+                  </td>
+                  <td>{u.active ? 'Yes' : 'No'}</td>
+                  <td>
+                    <button onClick={submitEdit}>Save</button>
+                    <button onClick={() => setEditingId(null)}>Cancel</button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td>{u.id}</td>
+                  <td>{u.username}</td>
+                  <td>{u.name}</td>
+                  <td>{u.active ? 'Yes' : 'No'}</td>
+                  <td className="space-x-2">
+                    <button onClick={() => startEdit(u)}>Edit</button>
+                    <button onClick={() => handleToggle(u)}>
+                      {u.active ? 'Deactivate' : 'Activate'}
+                    </button>
+                    <button onClick={() => handleDelete(u.id)}>Delete</button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@ import Dashboard from './pages/Dashboard';
 import MessagesList from './pages/MessagesList';
 import MessageDetail from './pages/MessageDetail';
 import UsersAdmin from './pages/UsersAdmin';
+import ChangePassword from './pages/ChangePassword';
 import NotFound from './pages/NotFound';
 import { ProtectedRoute } from './components/ProtectedRoute';
 
@@ -49,6 +50,14 @@ export default function Router() {
         element={
           <ProtectedRoute>
             <UsersAdmin />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/change-password"
+        element={
+          <ProtectedRoute>
+            <ChangePassword />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/test/__mocks__/serverB.ts
+++ b/frontend/src/test/__mocks__/serverB.ts
@@ -30,10 +30,23 @@ export function mockServerB() {
     if (url.endsWith('/api/users')) {
       return Promise.resolve(
         new Response(
-          JSON.stringify([{ id: '1', username: 'admin', role: 'admin' }]),
+          JSON.stringify([
+            {
+              id: 1,
+              name: 'Admin',
+              username: 'admin',
+              daily_quota: 100,
+              api_key: 'key',
+              note: '',
+              active: true,
+            },
+          ]),
           { status: 200 }
         )
       );
+    }
+    if (url.includes('/api/users/') && url.endsWith('/password')) {
+      return Promise.resolve(new Response('{}', { status: 200 }));
     }
     return Promise.reject(new Error('Unknown endpoint: ' + url));
   };

--- a/frontend/src/test/pages/change-password.test.tsx
+++ b/frontend/src/test/pages/change-password.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import ChangePassword from '../../pages/ChangePassword';
+import { AuthProvider } from '../../hooks/useAuth';
+import { mockServerB } from '../__mocks__/serverB';
+
+mockServerB();
+
+describe('ChangePassword', () => {
+  it('renders change password form', async () => {
+    localStorage.setItem('user', 'admin');
+    localStorage.setItem('token', 'mock');
+    render(
+      <AuthProvider>
+        <BrowserRouter>
+          <ChangePassword />
+        </BrowserRouter>
+      </AuthProvider>
+    );
+    expect(await screen.findByText('Change Password')).toBeInTheDocument();
+  });
+});

--- a/server-b/app/main.py
+++ b/server-b/app/main.py
@@ -7,6 +7,7 @@ from .logging import configure_logging
 from .status_api import router as status_router
 from .webhooks import router as webhook_router
 from .auth import router as auth_router
+from .users import router as users_router
 
 app = FastAPI(title=settings.service_name)
 
@@ -32,3 +33,4 @@ async def metrics_endpoint() -> PlainTextResponse:
 app.include_router(status_router)
 app.include_router(webhook_router)
 app.include_router(auth_router)
+app.include_router(users_router)

--- a/server-b/app/models.py
+++ b/server-b/app/models.py
@@ -1,7 +1,7 @@
 import enum
 import uuid
 from datetime import datetime
-from sqlalchemy import String, Integer, Enum, DateTime, ForeignKey, JSON
+from sqlalchemy import String, Integer, Enum, DateTime, ForeignKey, JSON, Boolean
 from sqlalchemy.orm import declarative_base, relationship, Mapped, mapped_column
 
 Base = declarative_base()
@@ -54,3 +54,16 @@ class MessageEvent(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     message: Mapped[Message] = relationship("Message", back_populates="events")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String)
+    username: Mapped[str] = mapped_column(String, unique=True)
+    daily_quota: Mapped[int] = mapped_column(Integer)
+    api_key: Mapped[str] = mapped_column(String)
+    password: Mapped[str] = mapped_column(String)
+    note: Mapped[str | None] = mapped_column(String, nullable=True)
+    active: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/server-b/app/schemas.py
+++ b/server-b/app/schemas.py
@@ -32,3 +32,32 @@ class EventOut(BaseModel):
 
 class MessageWithEventsOut(MessageStatusOut):
     events: List[EventOut]
+
+
+class UserBase(BaseModel):
+    name: str
+    username: str
+    daily_quota: int
+    api_key: str
+    note: Optional[str] = None
+    active: bool = True
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class UserOut(UserBase):
+    id: int
+
+
+class UserUpdate(BaseModel):
+    name: Optional[str] = None
+    daily_quota: Optional[int] = None
+    api_key: Optional[str] = None
+    note: Optional[str] = None
+    active: Optional[bool] = None
+
+
+class PasswordChange(BaseModel):
+    password: str

--- a/server-b/app/users.py
+++ b/server-b/app/users.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from .db import get_session
+from .repositories import UserRepository
+from . import schemas
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+@router.get("", response_model=list[schemas.UserOut])
+async def list_users(session: AsyncSession = Depends(get_session)):
+    repo = UserRepository(session)
+    return await repo.list_users()
+
+
+@router.post("", response_model=schemas.UserOut)
+async def create_user(payload: schemas.UserCreate, session: AsyncSession = Depends(get_session)):
+    repo = UserRepository(session)
+    return await repo.create_user(**payload.model_dump())
+
+
+@router.put("/{user_id}", response_model=schemas.UserOut)
+async def update_user(user_id: int, payload: schemas.UserUpdate, session: AsyncSession = Depends(get_session)):
+    repo = UserRepository(session)
+    user = await repo.update_user(user_id, payload.model_dump(exclude_unset=True))
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.delete("/{user_id}")
+async def delete_user(user_id: int, session: AsyncSession = Depends(get_session)):
+    repo = UserRepository(session)
+    deleted = await repo.delete_user(user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"ok": True}
+
+
+@router.post("/{user_id}/activate", response_model=schemas.UserOut)
+async def activate_user(user_id: int, session: AsyncSession = Depends(get_session)):
+    repo = UserRepository(session)
+    user = await repo.update_user(user_id, {"active": True})
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.post("/{user_id}/deactivate", response_model=schemas.UserOut)
+async def deactivate_user(user_id: int, session: AsyncSession = Depends(get_session)):
+    repo = UserRepository(session)
+    user = await repo.update_user(user_id, {"active": False})
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.post("/{username}/password")
+async def change_password(username: str, payload: schemas.PasswordChange, session: AsyncSession = Depends(get_session)):
+    repo = UserRepository(session)
+    user = await repo.change_password(username, payload.password)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"ok": True}

--- a/server-b/tests/test_auth.py
+++ b/server-b/tests/test_auth.py
@@ -1,15 +1,40 @@
 import pytest
+from app.repositories import UserRepository
+from sqlalchemy import delete
+from app import models
 
 
 @pytest.mark.asyncio
-async def test_login_success(client):
+async def test_login_success(client, session):
+    await session.execute(delete(models.User))
+    await session.commit()
+    repo = UserRepository(session)
+    await repo.create_user(
+        name="Admin",
+        username="admin",
+        daily_quota=1000,
+        api_key="key",
+        password="changeme",
+        note=None,
+    )
     resp = await client.post("/api/auth/login", json={"username": "admin", "password": "changeme"})
     assert resp.status_code == 200
     assert resp.json() == {"access_token": "fake-token", "token_type": "bearer"}
 
 
 @pytest.mark.asyncio
-async def test_login_failure(client):
+async def test_login_failure(client, session):
+    await session.execute(delete(models.User))
+    await session.commit()
+    repo = UserRepository(session)
+    await repo.create_user(
+        name="Admin",
+        username="admin",
+        daily_quota=1000,
+        api_key="key",
+        password="changeme",
+        note=None,
+    )
     resp = await client.post("/api/auth/login", json={"username": "admin", "password": "wrong"})
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Invalid credentials"

--- a/server-b/tests/test_users.py
+++ b/server-b/tests/test_users.py
@@ -1,0 +1,45 @@
+import pytest
+from sqlalchemy import delete
+from app import models
+
+
+@pytest.mark.asyncio
+async def test_user_crud(client, session):
+    await session.execute(delete(models.User))
+    await session.commit()
+    # create
+    payload = {
+        "name": "User1",
+        "username": "user1",
+        "daily_quota": 100,
+        "api_key": "key1",
+        "password": "pass1",
+        "note": "note1"
+    }
+    resp = await client.post("/api/users", json=payload)
+    assert resp.status_code == 200
+    user_id = resp.json()["id"]
+
+    # list
+    resp = await client.get("/api/users")
+    assert len(resp.json()) == 1
+
+    # update
+    resp = await client.put(f"/api/users/{user_id}", json={"name": "User1-upd"})
+    assert resp.json()["name"] == "User1-upd"
+
+    # deactivate
+    resp = await client.post(f"/api/users/{user_id}/deactivate")
+    assert resp.json()["active"] is False
+
+    # change password
+    resp = await client.post(f"/api/users/{payload['username']}/password", json={"password": "newpass"})
+    assert resp.status_code == 200
+
+    # delete
+    resp = await client.delete(f"/api/users/{user_id}")
+    assert resp.status_code == 200
+
+    # final list
+    resp = await client.get("/api/users")
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- add SQLAlchemy User model and repository with CRUD and activation endpoints
- extend auth to check database users
- add React admin UI for managing users and a change-password page

## Testing
- `cd server-b && pytest`
- `cd frontend && npm test -- --run`
- `cd server-a && pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a8a861262083208778db4ce0061e63