### PR TITLE
Add user enable/disable toggle to management page

### DIFF
--- a/server-b/user_management/templates/user_management/user_list.html
+++ b/server-b/user_management/templates/user_management/user_list.html
@@ -45,6 +45,7 @@
                                         <summary class="btn btn-ghost h-8 w-24 flex items-center justify-center">Actions</summary>
                                         <div class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
                                             <a href="{% url 'user_update' user.pk %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Edit</a>
+                                            <a href="{% url 'user_toggle' user.pk %}" class="block px-4 py-2 text-sm {% if user.is_active %}text-red-700 hover:bg-red-100{% else %}text-green-700 hover:bg-green-100{% endif %}">{% if user.is_active %}Disable{% else %}Enable{% endif %}</a>
                                             <a href="{% url 'user_delete' user.pk %}" class="block px-4 py-2 text-sm text-red-700 hover:bg-red-100">Delete</a>
                                         </div>
                                     </details>

--- a/server-b/user_management/tests.py
+++ b/server-b/user_management/tests.py
@@ -1,3 +1,19 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
 
-# Create your tests here.
+
+class UserToggleActiveViewTests(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user("admin", "admin@example.com", "pass")
+        self.staff.is_staff = True
+        self.staff.save()
+        self.user = User.objects.create_user("user", "user@example.com", "pass")
+        self.client.force_login(self.staff)
+
+    def test_toggle_user_active(self):
+        self.assertTrue(self.user.is_active)
+        response = self.client.get(reverse("user_toggle", args=[self.user.pk]))
+        self.assertRedirects(response, reverse("user_list"))
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)

--- a/server-b/user_management/urls.py
+++ b/server-b/user_management/urls.py
@@ -1,9 +1,16 @@
 from django.urls import path
-from .views import UserListView, UserCreateView, UserUpdateView, UserDeleteView
+from .views import (
+    UserListView,
+    UserCreateView,
+    UserUpdateView,
+    UserDeleteView,
+    UserToggleActiveView,
+)
 
 urlpatterns = [
     path('users/', UserListView.as_view(), name='user_list'),
     path('users/create/', UserCreateView.as_view(), name='user_create'),
     path('users/<int:pk>/update/', UserUpdateView.as_view(), name='user_update'),
     path('users/<int:pk>/delete/', UserDeleteView.as_view(), name='user_delete'),
+    path('users/<int:pk>/toggle/', UserToggleActiveView.as_view(), name='user_toggle'),
 ]

--- a/server-b/user_management/views.py
+++ b/server-b/user_management/views.py
@@ -1,9 +1,9 @@
 from django.contrib.auth.models import User
-from django.views.generic import ListView, CreateView, UpdateView, DeleteView
+from django.views.generic import ListView, CreateView, UpdateView, DeleteView, View
 from django.urls import reverse_lazy
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
 
 class StaffRequiredMixin(UserPassesTestMixin):
@@ -63,4 +63,18 @@ class UserDeleteView(StaffRequiredMixin, DeleteView):
 
     def form_invalid(self, form):
         messages.error(self.request, "Error deleting user.")
+        return redirect(reverse_lazy('user_list'))
+
+
+class UserToggleActiveView(StaffRequiredMixin, View):
+    """Toggle a user's active status."""
+
+    def get(self, request, pk):
+        user = get_object_or_404(User, pk=pk)
+        user.is_active = not user.is_active
+        user.save()
+        if user.is_active:
+            messages.success(request, "User enabled successfully!")
+        else:
+            messages.success(request, "User disabled successfully!")
         return redirect(reverse_lazy('user_list'))


### PR DESCRIPTION
## Summary
- allow staff to toggle user activation from management page
- add test for toggling user active status

## Testing
- `cd server-b && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68abf341c3ac8320a75ae1753fbc14a6