### PR TITLE
fix: load toast styles for user notifications

### DIFF
--- a/server-b/sms_gateway_project/templates/base.html
+++ b/server-b/sms_gateway_project/templates/base.html
@@ -30,6 +30,7 @@
       }
     </script>
     {% load static %}
+    <link rel="stylesheet" href="{% static 'css/toastify.min.css' %}">
     {% block extra_head %}{% endblock extra_head %}
 </head>
 <body class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>


### PR DESCRIPTION
## Summary
- include Toastify CSS to render toast notifications

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68abf4ee48fc8320ae9e31bd332d4a06