### PR TITLE
Fix user edit view to display user details

### DIFF
--- a/server-b/user_management/tests.py
+++ b/server-b/user_management/tests.py
@@ -17,3 +17,19 @@ class UserToggleActiveViewTests(TestCase):
         self.assertRedirects(response, reverse("user_list"))
         self.user.refresh_from_db()
         self.assertFalse(self.user.is_active)
+
+
+class UserUpdateViewTests(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user("admin", "admin@example.com", "pass")
+        self.staff.is_staff = True
+        self.staff.save()
+        self.user = User.objects.create_user("user", "user@example.com", "pass")
+        self.client.force_login(self.staff)
+
+    def test_edit_user_displays_form_with_user_data(self):
+        response = self.client.get(reverse("user_update", args=[self.user.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "user_management/user_form.html")
+        form = response.context["form"]
+        self.assertEqual(form.instance, self.user)

--- a/server-b/user_management/views.py
+++ b/server-b/user_management/views.py
@@ -41,7 +41,7 @@ class UserCreateView(StaffRequiredMixin, CreateView):
 class UserUpdateView(StaffRequiredMixin, UpdateView):
     model = User
     form_class = UserChangeForm
-    template_name = 'user_management/user_list.html' # Render user_list.html
+    template_name = 'user_management/user_form.html'
     success_url = reverse_lazy('user_list')
 
     def form_valid(self, form):


### PR DESCRIPTION
## Summary
- Use dedicated `user_form.html` template in `UserUpdateView` to render user details for editing
- Add regression test ensuring edit view pre-populates form

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68abfa30cc9c83208d762c781f028a07