### PR TITLE
Refactor server-b to use Celery for scheduled state broadcasting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 services:
+  # --------------------------------------------------------------------------
+  #  Server A (FastAPI Gateway) and its Dependencies
+  # --------------------------------------------------------------------------
   server-a:
     build:
       context: ./server-a
@@ -50,38 +53,72 @@ services:
       timeout: 5s
       retries: 5
 
+  # --------------------------------------------------------------------------
+  #  Server B (Django Backend) and its Worker Services
+  # --------------------------------------------------------------------------
+
+  # Step 1: A dedicated, short-lived service just for running migrations.
+  # The other services will wait for this to complete successfully.
+  migration-b:
+    build:
+      context: ./server-b
+      dockerfile: Dockerfile
+    command: python manage.py migrate --noinput
+    env_file:
+      - ./server-b/.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # Step 2: The main Django web server (Gunicorn).
+  # Starts only after migrations are done.
   server-b:
     build:
       context: ./server-b
       dockerfile: Dockerfile
-    image: sms_gateway_server_b
+    command: gunicorn --bind 0.0.0.0:9000 sms_gateway_project.wsgi:application
     env_file:
       - ./server-b/.env
     ports:
       - "9000:9000"
     depends_on:
-      - rabbitmq
-      - postgres
-    command: >-
-      sh -c "python manage.py migrate && gunicorn --bind 0.0.0.0:9000 sms_gateway_project.wsgi:application"
+      migration-b:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
 
+  # Step 3: The Celery worker service for background tasks.
+  # Also waits for migrations to be done.
   celery-worker-b:
-    image: sms_gateway_server_b
+    build:
+      context: ./server-b
+      dockerfile: Dockerfile
+    command: celery -A sms_gateway_project worker -l info
     env_file:
       - ./server-b/.env
-    command: >-
-      sh -c "python manage.py migrate && celery -A sms_gateway_project worker -l info"
     depends_on:
-      - rabbitmq
-      - postgres
+      migration-b:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
 
+  # Step 4: The Celery Beat scheduler for periodic tasks.
+  # Also waits for migrations to be done.
   celery-beat-b:
-    image: sms_gateway_server_b
+    build:
+      context: ./server-b
+      dockerfile: Dockerfile
+    command: celery -A sms_gateway_project beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
     env_file:
       - ./server-b/.env
-    command: >-
-      sh -c "python manage.py migrate && celery -A sms_gateway_project beat -l info"
     depends_on:
-      - rabbitmq
-      - postgres
-
+      migration-b:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     build:
       context: ./server-b
       dockerfile: Dockerfile
+    image: sms_gateway_server_b
     env_file:
       - ./server-b/.env
     ports:
@@ -61,3 +62,22 @@ services:
     depends_on:
       - rabbitmq
       - postgres
+
+  celery-worker-b:
+    image: sms_gateway_server_b
+    env_file:
+      - ./server-b/.env
+    command: celery -A sms_gateway_project worker -l info
+    depends_on:
+      - rabbitmq
+      - postgres
+
+  celery-beat-b:
+    image: sms_gateway_server_b
+    env_file:
+      - ./server-b/.env
+    command: celery -A sms_gateway_project beat -l info
+    depends_on:
+      - rabbitmq
+      - postgres
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,12 +62,15 @@ services:
     depends_on:
       - rabbitmq
       - postgres
+    command: >-
+      sh -c "python manage.py migrate && gunicorn --bind 0.0.0.0:9000 sms_gateway_project.wsgi:application"
 
   celery-worker-b:
     image: sms_gateway_server_b
     env_file:
       - ./server-b/.env
-    command: celery -A sms_gateway_project worker -l info
+    command: >-
+      sh -c "python manage.py migrate && celery -A sms_gateway_project worker -l info"
     depends_on:
       - rabbitmq
       - postgres
@@ -76,7 +79,8 @@ services:
     image: sms_gateway_server_b
     env_file:
       - ./server-b/.env
-    command: celery -A sms_gateway_project beat -l info
+    command: >-
+      sh -c "python manage.py migrate && celery -A sms_gateway_project beat -l info"
     depends_on:
       - rabbitmq
       - postgres

--- a/server-b/core/apps.py
+++ b/server-b/core/apps.py
@@ -1,19 +1,7 @@
 from django.apps import AppConfig
-from django.conf import settings
-import os
-import sys
 
 
 class CoreConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'core'
 
-    def ready(self):
-        """Start background tasks once Django is ready."""
-        # Avoid running twice with the reloader in development
-        if "test" in sys.argv:
-            return
-        if os.environ.get("RUN_MAIN") == "true" or not settings.DEBUG:
-            from .state_broadcaster import start_periodic_broadcast
-
-            start_periodic_broadcast()

--- a/server-b/requirements.txt
+++ b/server-b/requirements.txt
@@ -9,3 +9,5 @@ psycopg2-binary
 requests
 whitenoise
 gunicorn
+celery
+django-celery-beat

--- a/server-b/sms_gateway_project/__init__.py
+++ b/server-b/sms_gateway_project/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/server-b/sms_gateway_project/celery.py
+++ b/server-b/sms_gateway_project/celery.py
@@ -1,0 +1,10 @@
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'sms_gateway_project.settings')
+
+app = Celery('sms_gateway_project')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()
+
+

--- a/server-b/sms_gateway_project/settings.py
+++ b/server-b/sms_gateway_project/settings.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+from datetime import timedelta
 import dj_database_url
 from dotenv import load_dotenv
 
@@ -41,6 +42,7 @@ INSTALLED_APPS = [
     'core',
     'providers',
     'messaging',
+    'django_celery_beat',
 ]
 
 AUTHENTICATION_BACKENDS = [
@@ -150,3 +152,17 @@ RABBITMQ_USER = os.environ.get('RABBITMQ_USER', 'guest')
 RABBITMQ_PASS = os.environ.get('RABBITMQ_PASS', 'guest')
 CONFIG_EVENTS_EXCHANGE = os.environ.get('CONFIG_EVENTS_EXCHANGE', 'config_events_exchange')
 CONFIG_STATE_EXCHANGE = os.environ.get('CONFIG_STATE_EXCHANGE', 'config_state_exchange')
+
+CELERY_BROKER_URL = os.environ.get(
+    'CELERY_BROKER_URL',
+    f'amqp://{RABBITMQ_USER}:{RABBITMQ_PASS}@{RABBITMQ_HOST}//',
+)
+CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', CELERY_BROKER_URL)
+CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+CELERY_IMPORTS = ('core.state_broadcaster',)
+CELERY_BEAT_SCHEDULE = {
+    'publish-full-state': {
+        'task': 'core.state_broadcaster.publish_full_state',
+        'schedule': timedelta(seconds=60),
+    }
+}

--- a/server-b/sms_gateway_project/settings.py
+++ b/server-b/sms_gateway_project/settings.py
@@ -157,7 +157,7 @@ CELERY_BROKER_URL = os.environ.get(
     'CELERY_BROKER_URL',
     f'amqp://{RABBITMQ_USER}:{RABBITMQ_PASS}@{RABBITMQ_HOST}//',
 )
-CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', CELERY_BROKER_URL)
+CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', 'rpc://')
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 CELERY_IMPORTS = ('core.state_broadcaster',)
 CELERY_BEAT_SCHEDULE = {


### PR DESCRIPTION
## Summary
- integrate Celery and django-celery-beat in server-b
- move state broadcasting to a shared Celery task
- add Celery worker and beat services in docker compose

## Testing
- `python manage.py test` *(fails: settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_b_68b15ed4b06c83209d0be6056baf624e