### PR TITLE
feat: consume dynamic config state

### DIFF
--- a/server-a/app/cache.py
+++ b/server-a/app/cache.py
@@ -1,5 +1,80 @@
+import json
+from pathlib import Path
 from typing import Dict
 
-from app.config import ClientConfig
+from app.config import ClientConfig, ProviderConfig, normalize_provider_key
 
+# In-memory caches populated from configuration state broadcasts
 CLIENT_CONFIG_CACHE: Dict[str, ClientConfig] = {}
+PROVIDER_CONFIG_CACHE: Dict[str, ProviderConfig] = {}
+PROVIDER_ALIAS_MAP_CACHE: Dict[str, str] = {}
+
+# Path to the local on-disk cache used for warm starts
+CONFIG_CACHE_PATH = Path(__file__).resolve().parent / "state" / "config_cache.json"
+CONFIG_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _build_provider_alias_map(providers: Dict[str, ProviderConfig]) -> Dict[str, str]:
+    """Create a mapping of normalized provider aliases to canonical names.
+
+    Raises:
+        ValueError: if two providers share the same alias.
+    """
+
+    alias_map: Dict[str, str] = {}
+    for name, cfg in providers.items():
+        aliases = [name] + (cfg.aliases or [])
+        for alias in aliases:
+            key = normalize_provider_key(alias)
+            existing = alias_map.get(key)
+            if existing and existing != name:
+                raise ValueError(
+                    f"Alias collision: '{alias.lower()}' already maps to '{existing.lower()}', cannot map to '{name.lower()}'"
+                )
+            alias_map[key] = name
+    return alias_map
+
+
+def apply_state(state: Dict) -> None:
+    """Replace all in-memory caches with the given state."""
+
+    users = state.get("users", {})
+    providers = state.get("providers", {})
+
+    new_client_cache = {k: ClientConfig(**v) for k, v in users.items()}
+    new_provider_cache = {k: ProviderConfig(**v) for k, v in providers.items()}
+    new_alias_map = _build_provider_alias_map(new_provider_cache)
+
+    CLIENT_CONFIG_CACHE.clear()
+    CLIENT_CONFIG_CACHE.update(new_client_cache)
+
+    PROVIDER_CONFIG_CACHE.clear()
+    PROVIDER_CONFIG_CACHE.update(new_provider_cache)
+
+    PROVIDER_ALIAS_MAP_CACHE.clear()
+    PROVIDER_ALIAS_MAP_CACHE.update(new_alias_map)
+
+
+def save_state_to_file(state: Dict) -> None:
+    """Persist the raw state to the local cache file."""
+    with CONFIG_CACHE_PATH.open("w") as f:
+        json.dump(state, f)
+
+
+def load_state_from_file() -> bool:
+    """Load state from disk into caches.
+
+    Returns True on success, False otherwise.
+    """
+
+    try:
+        with CONFIG_CACHE_PATH.open("r") as f:
+            state = json.load(f)
+        apply_state(state)
+        return True
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        return False
+
+
+# Expose helper for tests
+build_provider_alias_map = _build_provider_alias_map

--- a/server-a/app/consumers.py
+++ b/server-a/app/consumers.py
@@ -1,19 +1,27 @@
-import json
 import asyncio
-import aio_pika
-from app.config import get_settings
-from app.cache import CLIENT_CONFIG_CACHE, ClientConfig
+import json
+import logging
 
-async def consume_config_events():
+import aio_pika
+
+from app.cache import apply_state, save_state_to_file
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+async def consume_config_state() -> None:
+    """Background task that listens for full configuration state broadcasts."""
+
     settings = get_settings()
     connection = await aio_pika.connect_robust(
-        f"amqp://{settings.rabbit_user}:{settings.rabbit_pass}@{settings.rabbit_host}/"
+        settings.RABBITMQ_URL
     )
 
     async with connection:
         channel = await connection.channel()
         exchange = await channel.declare_exchange(
-            'config_events_exchange', aio_pika.ExchangeType.FANOUT, durable=True
+            "config_state_exchange", aio_pika.ExchangeType.FANOUT, durable=True
         )
         queue = await channel.declare_queue(exclusive=True)
         await queue.bind(exchange)
@@ -21,14 +29,13 @@ async def consume_config_events():
         async with queue.iterator() as queue_iter:
             async for message in queue_iter:
                 async with message.process():
-                    event_type = message.type
-                    body = message.body.decode()
-                    data = json.loads(body)
+                    try:
+                        payload = json.loads(message.body.decode())
+                        apply_state(payload)
+                        save_state_to_file(payload)
+                        logger.info("Configuration state updated from broadcast.")
+                    except Exception:
+                        logger.exception("Failed to process configuration state message")
 
-                    if event_type == 'user.updated':
-                        api_key = data.pop('api_key')
-                        CLIENT_CONFIG_CACHE[api_key] = ClientConfig(**data)
-                    elif event_type == 'user.deleted':
-                        api_key = data['api_key']
-                        if api_key in CLIENT_CONFIG_CACHE:
-                            del CLIENT_CONFIG_CACHE[api_key]
+
+__all__ = ["consume_config_state"]

--- a/server-a/app/metrics.py
+++ b/server-a/app/metrics.py
@@ -4,7 +4,7 @@ from fastapi import Response
 from typing import Dict, Any
 import logging
 
-from app.config import get_settings
+from app.cache import PROVIDER_CONFIG_CACHE
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +78,8 @@ SMS_SEND_REQUEST_ERROR_TOTAL = Counter(
 )
 
 def initialize_provider_metrics():
-    """Initializes provider-specific gauges based on current configuration."""
-    settings = get_settings()
-    providers_config = settings.providers
+    """Initializes provider-specific gauges based on current cache state."""
+    providers_config = PROVIDER_CONFIG_CACHE
     SMS_PROVIDERS_CONFIG_TOTAL.set(len(providers_config))
 
     for provider_name, config in providers_config.items():

--- a/server-a/app/provider_gate.py
+++ b/server-a/app/provider_gate.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 from fastapi import HTTPException, status, Request
 
 from app import config
+from app.cache import PROVIDER_ALIAS_MAP_CACHE, PROVIDER_CONFIG_CACHE
 from app.config import ProviderConfig
 from app.metrics import (
     SMS_REQUEST_REJECTED_UNKNOWN_PROVIDER_TOTAL,
@@ -15,8 +16,9 @@ logger = logging.getLogger(__name__)
 class ProviderGate:
     def __init__(self):
         self.settings = config.get_settings()
-        self.provider_alias_map = self.settings.provider_alias_map
-        self.providers_config = self.settings.providers
+        # Reference global caches so they stay updated when refreshed
+        self.provider_alias_map = PROVIDER_ALIAS_MAP_CACHE
+        self.providers_config = PROVIDER_CONFIG_CACHE
 
     def _get_canonical_provider_name(self, provider_name: str) -> Optional[str]:
         """Returns the canonical provider name using normalized keys with a lowercase fallback."""

--- a/server-a/app/state/.gitignore
+++ b/server-a/app/state/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/server-a/tests/test_health_readiness.py
+++ b/server-a/tests/test_health_readiness.py
@@ -19,12 +19,7 @@ def mock_settings():
         IDEMPOTENCY_TTL_SECONDS=10,
         QUOTA_PREFIX="test-quota",
         HEARTBEAT_INTERVAL_SECONDS=60,
-        CLIENT_CONFIG='{"client_key_1":{"name":"Test Client 1","is_active":true,"daily_quota":100}}',
-        PROVIDERS_CONFIG='{"ProviderA":{"is_active":true,"is_operational":true}}'
     )
-    _ = settings.clients
-    _ = settings.providers
-    _ = settings.provider_alias_map
     return settings
 
 @pytest.fixture

--- a/server-a/tests/test_idempotency.py
+++ b/server-a/tests/test_idempotency.py
@@ -28,12 +28,7 @@ def mock_settings():
         IDEMPOTENCY_TTL_SECONDS=10, # Short TTL for testing
         QUOTA_PREFIX="quota",
         HEARTBEAT_INTERVAL_SECONDS=60,
-        CLIENT_CONFIG='{"client_key_1":{"name":"Test Client 1","is_active":true,"daily_quota":100}}',
-        PROVIDERS_CONFIG='{"ProviderA":{"is_active":true,"is_operational":true}}'
     )
-    _ = settings.clients
-    _ = settings.providers
-    _ = settings.provider_alias_map
     return settings
 
 # Mock Redis client

--- a/server-a/tests/test_quota.py
+++ b/server-a/tests/test_quota.py
@@ -23,12 +23,7 @@ def mock_settings():
         IDEMPOTENCY_TTL_SECONDS=86400,
         QUOTA_PREFIX="test-quota",
         HEARTBEAT_INTERVAL_SECONDS=60,
-        CLIENT_CONFIG='{"client_key_1":{"name":"Test Client 1","is_active":true,"daily_quota":10}, "client_key_unlimited":{"name":"Unlimited Client","is_active":true,"daily_quota":0}}',
-        PROVIDERS_CONFIG='{"ProviderA":{"is_active":true,"is_operational":true}}'
     )
-    _ = settings.clients
-    _ = settings.providers
-    _ = settings.provider_alias_map
     return settings
 
 # Mock Redis client
@@ -50,12 +45,12 @@ def test_app_quota(mock_settings, mock_redis_client):
 
         # Dummy auth dependency to simulate getting a client context
         async def get_test_client_context(request: Request) -> ClientContext:
-            client = ClientContext(api_key="client_key_1", name="Test Client 1", is_active=True, daily_quota=10)
+            client = ClientContext(api_key="client_key_1", user_id=1, username="Test Client 1", is_active=True, daily_quota=10)
             request.state.client = client # Attach to request state
             return client
 
         async def get_unlimited_client_context(request: Request) -> ClientContext:
-            client = ClientContext(api_key="client_key_unlimited", name="Unlimited Client", is_active=True, daily_quota=0)
+            client = ClientContext(api_key="client_key_unlimited", user_id=2, username="Unlimited Client", is_active=True, daily_quota=0)
             request.state.client = client
             return client
 
@@ -159,7 +154,7 @@ def test_app_rejection(mock_settings, mock_redis_client):
 
     # Mock client context dependency
     async def get_test_client_context(request: Request) -> ClientContext:
-        client = ClientContext(api_key="client_key_1", name="Test Client 1", is_active=True, daily_quota=10)
+        client = ClientContext(api_key="client_key_1", user_id=1, username="Test Client 1", is_active=True, daily_quota=10)
         request.state.client = client
         return client
 

--- a/server-a/tests/test_send_endpoint.py
+++ b/server-a/tests/test_send_endpoint.py
@@ -28,25 +28,19 @@ def mock_settings():
         IDEMPOTENCY_TTL_SECONDS=10,
         QUOTA_PREFIX="test-quota",
         HEARTBEAT_INTERVAL_SECONDS=60,
-        CLIENT_CONFIG='{"client_key_1":{"name":"Test Client 1","is_active":true,"daily_quota":100}}',
-        PROVIDERS_CONFIG='{"ProviderA":{"is_active":true,"is_operational":true}}'
     )
-    _ = settings.clients
-    _ = settings.providers
-    _ = settings.provider_alias_map
     return settings
 
 # Mock dependencies for the send_sms endpoint
 @pytest.fixture
 def mock_dependencies(mock_settings):
     with patch('app.config.get_settings', return_value=mock_settings), \
-         patch('app.auth.get_settings', return_value=mock_settings), \
          patch('app.idempotency.settings', mock_settings), \
          patch('app.quota.get_settings', return_value=mock_settings), \
          patch('app.rabbit.get_settings', return_value=mock_settings), \
          patch('app.heartbeat.get_settings', return_value=mock_settings):
 
-        mock_get_client_context = AsyncMock(return_value=ClientContext(api_key="client_key_1", name="Test Client 1", is_active=True, daily_quota=100))
+        mock_get_client_context = AsyncMock(return_value=ClientContext(api_key="client_key_1", user_id=1, username="Test Client 1", is_active=True, daily_quota=100))
         mock_provider_gate_process_providers = MagicMock(return_value=["ProviderA"])
         mock_enforce_daily_quota = AsyncMock()
         mock_publish_sms_message = AsyncMock()


### PR DESCRIPTION
## Summary
- cache full config state to disk and in-memory dictionaries
- subscribe to config_state_exchange and refresh caches on broadcasts
- warm caches from local file at startup and use in ProviderGate

## Testing
- `pytest server-a/tests`


------
https://chatgpt.com/codex/tasks/task_b_68b172d05bbc83209023c4bf8d39e28c