### PR TITLE
Add E2E configuration sync tests and workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,34 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install test dependencies
+        run: pip install pytest requests
+
+      - name: Start services
+        run: docker-compose up -d --build
+
+      - name: Wait for services to be healthy
+        run: sleep 30
+
+      - name: Run E2E tests
+        run: pytest tests/e2e/
+
+      - name: Stop services
+        if: always()
+        run: docker-compose down -v

--- a/tests/e2e/test_config_sync.py
+++ b/tests/e2e/test_config_sync.py
@@ -1,0 +1,91 @@
+import subprocess
+import time
+from uuid import uuid4
+
+import pytest
+import requests
+
+
+@pytest.fixture(scope="module", autouse=True)
+def compose_environment():
+    """Spin up the docker-compose environment for the test module."""
+    subprocess.run(["docker-compose", "up", "-d", "--build"], check=True)
+    # Wait for services to come up
+    start = time.time()
+    while time.time() - start < 60:
+        try:
+            resp = requests.get("http://localhost:8001/readyz", timeout=5)
+            if resp.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:
+        raise RuntimeError("Services did not become ready in time")
+    yield
+    subprocess.run(["docker-compose", "down", "-v"], check=True)
+
+
+def _send_request(provider_name: str) -> requests.Response:
+    payload = {
+        "to": "+15555550100",
+        "text": "test message",
+        "providers": [provider_name],
+        "ttl_seconds": 3600,
+    }
+    headers = {
+        "API-Key": "api_key_for_service_A",
+        "Idempotency-Key": str(uuid4()),
+    }
+    return requests.post("http://localhost:8001/api/v1/sms/send", json=payload, headers=headers, timeout=10)
+
+
+def test_real_time_sync_of_disabled_provider():
+    provider_name = "ProviderA"
+    disable_cmd = [
+        "docker-compose",
+        "exec",
+        "-T",
+        "server-b",
+        "python",
+        "manage.py",
+        "shell",
+        "-c",
+        (
+            f"from providers.models import SmsProvider; "
+            f"p=SmsProvider.objects.get(name='{provider_name}'); "
+            "p.is_active=False; p.save()"
+        ),
+    ]
+    subprocess.run(disable_cmd, check=True)
+    time.sleep(70)
+    response = _send_request(provider_name)
+    assert response.status_code == 409
+    body = response.json()
+    assert body.get("error_code") == "PROVIDER_DISABLED"
+    enable_cmd = [
+        "docker-compose",
+        "exec",
+        "-T",
+        "server-b",
+        "python",
+        "manage.py",
+        "shell",
+        "-c",
+        (
+            f"from providers.models import SmsProvider; "
+            f"p=SmsProvider.objects.get(name='{provider_name}'); "
+            "p.is_active=True; p.save()"
+        ),
+    ]
+    subprocess.run(enable_cmd, check=True)
+
+
+def test_startup_recovery_from_file_cache():
+    provider_name = "ProviderA"
+    subprocess.run(["docker-compose", "restart", "server-a"], check=True)
+    time.sleep(10)
+    response = _send_request(provider_name)
+    assert response.status_code == 409
+    body = response.json()
+    assert body.get("error_code") == "PROVIDER_DISABLED"


### PR DESCRIPTION
## Summary
- add pytest-based E2E tests covering provider sync and cache recovery
- add GitHub Actions workflow to run docker-compose backed E2E tests

## Testing
- `pytest tests/e2e -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker-compose')*


------
https://chatgpt.com/codex/tasks/task_b_68b1a6b8b7e88320a1b8930d5fdc991e