### PR TITLE
Add server-b health check and deterministic E2E tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,7 @@ IDEMPOTENCY_TTL_SECONDS=86400
 QUOTA_PREFIX=quota
 HEARTBEAT_INTERVAL_SECONDS=60
 CLIENT_CONFIG={"api_key_for_service_A":{"name":"Financial Service","is_active":true,"daily_quota":1000}}
-PROVIDERS_CONFIG={
-  "Provider-A":{"is_active":true,"is_operational":true,"aliases":["provider-a","PROVIDER_A"],"note":"active"},
-  "Provider-B":{"is_active":false,"is_operational":false,"note":"disabled"},
-  "Local-SMS":{"is_active":true,"is_operational":true,"note":"offline module"}
-}
+PROVIDERS_CONFIG={"ProviderA":{"is_active":true,"is_operational":true,"aliases":["provider-a","PROVIDER_A"],"note":"active"},"ProviderB":{"is_active":false,"is_operational":false,"note":"disabled"},"LocalSMS":{"is_active":true,"is_operational":true,"note":"offline module"}}
 # Server B
 SERVICE_NAME=server-b
 SERVER_B_HOST=0.0.0.0
@@ -20,7 +16,7 @@ SERVER_B_PORT=9000
 RABBITMQ_QUEUE_OUTBOUND=sms.outbound
 RABBITMQ_QUEUE_HEARTBEAT=a.heartbeat
 RABBITMQ_PREFETCH=32
-DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/smsgw
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/smsgw
 MAX_SEND_ATTEMPTS=10
 DEFAULT_TTL_SECONDS=3600
 MIN_TTL_SECONDS=10

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   e2e-tests:
@@ -20,15 +23,5 @@ jobs:
       - name: Install test dependencies
         run: pip install pytest requests
 
-      - name: Start services
-        run: docker-compose up -d --build
-
-      - name: Wait for services to be healthy
-        run: sleep 30
-
       - name: Run E2E tests
         run: pytest tests/e2e/
-
-      - name: Stop services
-        if: always()
-        run: docker-compose down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,18 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9000/healthz/').status==200 else 1)",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   # Step 3: The Celery worker service for background tasks.
   # Also waits for migrations to be done.

--- a/server-b/core/urls.py
+++ b/server-b/core/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.dashboard, name='dashboard'),
+    path('healthz/', views.healthz, name='healthz'),
 ]

--- a/server-b/core/views.py
+++ b/server-b/core/views.py
@@ -1,6 +1,19 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
+from django.db import connection
+from django.db.utils import OperationalError
 
 @login_required
 def dashboard(request):
     return render(request, 'core/dashboard.html')
+
+
+def healthz(request):
+    """Lightweight readiness check for the Django app and database."""
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        return JsonResponse({"status": "ok"})
+    except OperationalError as exc:
+        return JsonResponse({"status": "error", "details": str(exc)}, status=503)

--- a/tests/e2e/test_config_sync.py
+++ b/tests/e2e/test_config_sync.py
@@ -1,5 +1,6 @@
 import subprocess
 import time
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -8,22 +9,66 @@ import requests
 
 @pytest.fixture(scope="module", autouse=True)
 def compose_environment():
-    """Spin up the docker-compose environment for the test module."""
-    subprocess.run(["docker-compose", "up", "-d", "--build"], check=True)
-    # Wait for services to come up
-    start = time.time()
-    while time.time() - start < 60:
-        try:
-            resp = requests.get("http://localhost:8001/readyz", timeout=5)
-            if resp.status_code == 200:
-                break
-        except Exception:
-            pass
-        time.sleep(1)
-    else:
-        raise RuntimeError("Services did not become ready in time")
+    """Create env files, start services, and seed required data."""
+    root = Path(__file__).resolve().parents[2]
+    env_example = root / ".env.example"
+    server_a_env = root / "server-a" / ".env"
+    server_b_env = root / "server-b" / ".env"
+
+    server_a_lines = []
+    server_b_lines = []
+    section = "server_a"
+    with env_example.open() as fh:
+        for line in fh:
+            if line.startswith("# Server B"):
+                section = "server_b"
+                continue
+            if line.startswith("# Frontend"):
+                section = None
+                continue
+            if line.startswith("#") or not line.strip():
+                continue
+            if section == "server_a":
+                server_a_lines.append(line)
+            elif section == "server_b":
+                server_b_lines.append(line)
+
+    # Append shared client/provider config to server-b env
+    for line in server_a_lines:
+        if line.startswith("CLIENT_CONFIG") or line.startswith("PROVIDERS_CONFIG"):
+            server_b_lines.append(line)
+
+    server_a_env.write_text("".join(server_a_lines))
+    server_b_env.write_text("".join(server_b_lines))
+
+    subprocess.run(["docker", "compose", "up", "-d", "--build", "--wait"], check=True)
+
+    init_script = (
+        "from django.contrib.auth.models import User;"
+        "from user_management.models import Profile;"
+        "from providers.models import SmsProvider;"
+        "user,_=User.objects.get_or_create(username='testuser');"
+        "Profile.objects.update_or_create(user=user, defaults={'api_key': 'api_key_for_e2e_tests'});"
+        "SmsProvider.objects.get_or_create(name='ProviderA', defaults={'is_active': True, 'is_operational': True})"
+    )
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "exec",
+            "-T",
+            "server-b",
+            "python",
+            "manage.py",
+            "shell",
+            "-c",
+            init_script,
+        ],
+        check=True,
+    )
+
     yield
-    subprocess.run(["docker-compose", "down", "-v"], check=True)
+    subprocess.run(["docker", "compose", "down", "-v"], check=True)
 
 
 def _send_request(provider_name: str) -> requests.Response:
@@ -34,16 +79,21 @@ def _send_request(provider_name: str) -> requests.Response:
         "ttl_seconds": 3600,
     }
     headers = {
-        "API-Key": "api_key_for_service_A",
+        "API-Key": "api_key_for_e2e_tests",
         "Idempotency-Key": str(uuid4()),
     }
-    return requests.post("http://localhost:8001/api/v1/sms/send", json=payload, headers=headers, timeout=10)
-
-
-def test_real_time_sync_of_disabled_provider():
+    return requests.post(
+        "http://localhost:8001/api/v1/sms/send",
+        json=payload,
+        headers=headers,
+        timeout=10,
+    )
+def test_real_time_sync_and_recovery_flow():
     provider_name = "ProviderA"
-    disable_cmd = [
-        "docker-compose",
+
+    enable_cmd = [
+        "docker",
+        "compose",
         "exec",
         "-T",
         "server-b",
@@ -52,19 +102,49 @@ def test_real_time_sync_of_disabled_provider():
         "shell",
         "-c",
         (
-            f"from providers.models import SmsProvider; "
-            f"p=SmsProvider.objects.get(name='{provider_name}'); "
+            "from providers.models import SmsProvider; "
+            "p,_=SmsProvider.objects.get_or_create(name='ProviderA', defaults={'is_active': True, 'is_operational': True}); "
+            "p.is_active=True; p.save()"
+        ),
+    ]
+    subprocess.run(enable_cmd, check=True)
+    time.sleep(70)
+    ok_response = _send_request(provider_name)
+    assert ok_response.status_code == 202
+
+    disable_cmd = [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "server-b",
+        "python",
+        "manage.py",
+        "shell",
+        "-c",
+        (
+            "from providers.models import SmsProvider; "
+            "p=SmsProvider.objects.get(name='ProviderA'); "
             "p.is_active=False; p.save()"
         ),
     ]
     subprocess.run(disable_cmd, check=True)
     time.sleep(70)
-    response = _send_request(provider_name)
-    assert response.status_code == 409
-    body = response.json()
+    fail_response = _send_request(provider_name)
+    assert fail_response.status_code == 409
+    body = fail_response.json()
     assert body.get("error_code") == "PROVIDER_DISABLED"
-    enable_cmd = [
-        "docker-compose",
+
+    subprocess.run(["docker", "compose", "restart", "server-a"], check=True)
+    time.sleep(10)
+    fail_response = _send_request(provider_name)
+    assert fail_response.status_code == 409
+    body = fail_response.json()
+    assert body.get("error_code") == "PROVIDER_DISABLED"
+
+    cleanup_cmd = [
+        "docker",
+        "compose",
         "exec",
         "-T",
         "server-b",
@@ -73,19 +153,10 @@ def test_real_time_sync_of_disabled_provider():
         "shell",
         "-c",
         (
-            f"from providers.models import SmsProvider; "
-            f"p=SmsProvider.objects.get(name='{provider_name}'); "
+            "from providers.models import SmsProvider; "
+            "p=SmsProvider.objects.get(name='ProviderA'); "
             "p.is_active=True; p.save()"
         ),
     ]
-    subprocess.run(enable_cmd, check=True)
+    subprocess.run(cleanup_cmd, check=True)
 
-
-def test_startup_recovery_from_file_cache():
-    provider_name = "ProviderA"
-    subprocess.run(["docker-compose", "restart", "server-a"], check=True)
-    time.sleep(10)
-    response = _send_request(provider_name)
-    assert response.status_code == 409
-    body = response.json()
-    assert body.get("error_code") == "PROVIDER_DISABLED"


### PR DESCRIPTION
## Summary
- expose `/healthz` endpoint in server-b and wire Docker healthcheck
- run docker compose with `--wait` and seed test data in E2E suite
- create per-service env files in tests and combine sync & recovery checks

## Testing
- `pytest tests/e2e/test_config_sync.py -q --tb=short` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_b_68b1a9f31934832096d41c2eff8aa713