### PR TITLE
Add tracking ID search to message list

### DIFF
--- a/server-b/messaging/templates/messaging/message_list.html
+++ b/server-b/messaging/templates/messaging/message_list.html
@@ -49,6 +49,14 @@
     <!-- Card -->
     <section class="card">
         <div class="card__body">
+            <!-- Search -->
+            <form method="get" class="mb-4">
+                <input type="text" name="tracking_id" placeholder="Search by Tracking ID" value="{{ tracking_id }}">
+                <button type="submit">Search</button>
+                {% if tracking_id %}
+                    <a href="{% url 'messaging:my_messages_list' %}">Clear</a>
+                {% endif %}
+            </form>
             <!-- Table -->
             <div class="table-wrap">
                 <table>

--- a/server-b/messaging/tests.py
+++ b/server-b/messaging/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
+from django.urls import reverse
 from messaging.models import Message, MessageStatus
 from providers.models import SmsProvider, AuthType
 import uuid
@@ -36,3 +37,44 @@ class MessageModelTests(TestCase):
         )
         self.assertEqual(msg.status, MessageStatus.PENDING)
         self.assertEqual(str(msg), f"To: {msg.recipient} via N/A [{msg.status}]")
+
+
+class UserMessageListViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("user", password="pass")
+        self.provider = SmsProvider.objects.create(
+            name="Provider",
+            slug="provider",
+            send_url="http://example.com/send",
+            balance_url="http://example.com/balance",
+            default_sender="100",
+            auth_type=AuthType.NONE,
+        )
+        self.msg1 = Message.objects.create(
+            user=self.user,
+            tracking_id=uuid.uuid4(),
+            recipient="12345",
+            text="hello1",
+            provider=self.provider,
+        )
+        self.msg2 = Message.objects.create(
+            user=self.user,
+            tracking_id=uuid.uuid4(),
+            recipient="67890",
+            text="hello2",
+            provider=self.provider,
+        )
+
+    def test_search_by_tracking_id_filters_messages(self):
+        self.client.login(username="user", password="pass")
+        url = reverse("messaging:my_messages_list")
+        response = self.client.get(url, {"tracking_id": str(self.msg1.tracking_id)})
+        self.assertContains(response, self.msg1.recipient)
+        self.assertNotContains(response, self.msg2.recipient)
+        self.assertEqual(response.context["tracking_id"], str(self.msg1.tracking_id))
+
+    def test_invalid_tracking_id_returns_no_messages(self):
+        self.client.login(username="user", password="pass")
+        url = reverse("messaging:my_messages_list")
+        response = self.client.get(url, {"tracking_id": "not-a-uuid"})
+        self.assertEqual(list(response.context["messages"]), [])

--- a/server-b/messaging/views.py
+++ b/server-b/messaging/views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.views.generic import ListView
 from .models import Message
+import uuid
 
 
 class UserMessageListView(LoginRequiredMixin, ListView):
@@ -10,7 +11,20 @@ class UserMessageListView(LoginRequiredMixin, ListView):
     paginate_by = 25
 
     def get_queryset(self):
-        return Message.objects.filter(user=self.request.user).order_by('-sent_at')
+        queryset = Message.objects.filter(user=self.request.user).order_by('-sent_at')
+        tracking_id = self.request.GET.get('tracking_id', '').strip()
+        if tracking_id:
+            try:
+                uuid_obj = uuid.UUID(tracking_id)
+                queryset = queryset.filter(tracking_id=uuid_obj)
+            except ValueError:
+                queryset = Message.objects.none()
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['tracking_id'] = self.request.GET.get('tracking_id', '').strip()
+        return context
 
 class AdminMessageListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
     model = Message


### PR DESCRIPTION
## Summary
- Filter user messages by optional tracking ID query parameter and preserve input in context
- Provide search form in message list template with clear link to reset filters
- Add tests verifying tracking ID search filtering and invalid input handling

## Testing
- `pytest server-b/messaging/tests.py::UserMessageListViewTests::test_search_by_tracking_id_filters_messages server-b/messaging/tests.py::UserMessageListViewTests::test_invalid_tracking_id_returns_no_messages -q --ds=sms_gateway_project.settings`
- `pytest tests/e2e/test_config_sync.py::test_real_time_sync_of_disabled_provider -q` *(fails: FileNotFoundError: 'docker-compose')*

------
https://chatgpt.com/codex/tasks/task_b_68b293e96778832091631ee86fb090bd