### PR TITLE
feat: add client timezone support

### DIFF
--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -70,7 +70,7 @@
                             <td>{{ message.text|truncatechars:50 }}</td>
                             <td><span class="pill pill--on">{{ message.get_status_display }}</span></td>
                             <td>{{ message.provider.name }}</td>
-                            <td>{{ message.sent_at|date:"Y-m-d H:i" }}</td>
+                            <td class="utc-time" data-utc="{{ message.sent_at|date:'c' }}"></td>
                         </tr>
                         {% empty %}
                         <tr>

--- a/server-b/messaging/templates/messaging/message_detail.html
+++ b/server-b/messaging/templates/messaging/message_detail.html
@@ -40,7 +40,7 @@
                         {% for attempt in attempt_logs %}
                         <tr>
                             <td>{{ attempt.provider.name }}</td>
-                            <td>{{ attempt.timestamp|date:"Y-m-d H:i" }}</td>
+                            <td class="utc-time" data-utc="{{ attempt.timestamp|date:'c' }}"></td>
                             <td>{{ attempt.get_status_display }}</td>
                             <td><pre>{{ attempt.provider_response|default:'' }}</pre></td>
                         </tr>

--- a/server-b/messaging/templates/messaging/message_list.html
+++ b/server-b/messaging/templates/messaging/message_list.html
@@ -81,7 +81,7 @@
                                 {% endif %}
                             </td>
                             <td>{{ message.provider.name }}</td>
-                            <td>{{ message.sent_at|date:"Y-m-d H:i" }}</td>
+                            <td class="utc-time" data-utc="{{ message.sent_at|date:'c' }}"></td>
                         </tr>
                         {% empty %}
                         <tr>

--- a/server-b/sms_gateway_project/templates/base.html
+++ b/server-b/sms_gateway_project/templates/base.html
@@ -46,6 +46,7 @@
         <a href="{% url 'dashboard' %}" class="text-[#111418] text-lg font-bold leading-tight tracking-[-0.015em]">SMS Gateway</a>
     </div>
     <div class="flex flex-1 items-center justify-end gap-8">
+        <select id="timezone-select" class="text-sm border rounded px-2 py-1"></select>
         {% if user.is_staff %}
         <a class="text-[#111418] text-sm font-bold leading-normal tracking-[0.015em]" href="{% url 'sms_provider_list' %}">Providers</a>
         {% endif %}
@@ -90,6 +91,7 @@
         </div>
     </div>
 <script type="text/javascript" src="{% static 'js/toastify-js.js' %}"></script>
+<script type="module" src="{% static 'js/timezone.js' %}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         {% if messages %}

--- a/server-b/static/js/timezone.js
+++ b/server-b/static/js/timezone.js
@@ -1,0 +1,71 @@
+(function() {
+  function getStoredTimeZone() {
+    return localStorage.getItem('timezone');
+  }
+
+  function detectTimeZone() {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (e) {
+      return 'UTC';
+    }
+  }
+
+  function getTimeZone() {
+    return getStoredTimeZone() || detectTimeZone();
+  }
+
+  function formatToTimeZone(utcString, timeZone) {
+    const date = new Date(utcString);
+    const formatter = new Intl.DateTimeFormat('en-GB', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    const parts = formatter.formatToParts(date);
+    const values = Object.fromEntries(parts.map(p => [p.type, p.value]));
+    return `${values.year}-${values.month}-${values.day} ${values.hour}:${values.minute}`;
+  }
+
+  function convertTimes() {
+    const tz = getTimeZone();
+    document.querySelectorAll('.utc-time').forEach(el => {
+      const utc = el.getAttribute('data-utc');
+      if (utc) {
+        el.textContent = formatToTimeZone(utc, tz);
+      }
+    });
+  }
+
+  function populateSelect() {
+    const select = document.getElementById('timezone-select');
+    if (!select) return;
+    const zones = Intl.supportedValuesOf ? Intl.supportedValuesOf('timeZone') : [detectTimeZone()];
+    zones.forEach(z => {
+      const opt = document.createElement('option');
+      opt.value = z;
+      opt.textContent = z;
+      select.appendChild(opt);
+    });
+    select.value = getTimeZone();
+    select.addEventListener('change', () => {
+      localStorage.setItem('timezone', select.value);
+      convertTimes();
+    });
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+      populateSelect();
+      convertTimes();
+    });
+  }
+
+  if (typeof module !== 'undefined') {
+    module.exports = { formatToTimeZone };
+  }
+})();

--- a/tests/timezone.test.js
+++ b/tests/timezone.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { formatToTimeZone } = require('../server-b/static/js/timezone');
+
+const utc = '2024-01-01T12:00:00Z';
+const ny = formatToTimeZone(utc, 'America/New_York');
+assert.strictEqual(ny, '2024-01-01 07:00');
+
+const la = formatToTimeZone(utc, 'America/Los_Angeles');
+assert.strictEqual(la, '2024-01-01 04:00');
+
+console.log('Timezone tests passed');


### PR DESCRIPTION
## Summary
- detect browser timezone and convert UTC timestamps on the client
- allow users to choose a different timezone via dropdown
- add basic tests for timezone formatting

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker-compose')*
- `node tests/timezone.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b4009bcde48320b0b242c500abb322