### PR TITLE
Parse Magfa response into status summary

### DIFF
--- a/server-b/messaging/templates/messaging/message_detail.html
+++ b/server-b/messaging/templates/messaging/message_detail.html
@@ -42,7 +42,7 @@
                             <td>{{ attempt.provider.name }}</td>
                             <td class="utc-time" data-utc="{{ attempt.timestamp|date:'c' }}"></td>
                             <td>{{ attempt.get_status_display }}</td>
-                            <td><pre>{{ attempt.provider_response|default:'' }}</pre></td>
+                            <td><pre>{{ attempt.get_magfa_status_summary }}</pre></td>
                         </tr>
                         {% empty %}
                         <tr>


### PR DESCRIPTION
## Summary
- add MessageAttemptLog.get_magfa_status_summary helper parsing Magfa JSON and mapping status codes to readable messages
- show parsed Magfa status in message detail template
- test status summary handling for success, known error codes, overall failures, and malformed responses

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68b402a7e2c88320a707f5efdf40ad84