### PR TITLE
Move timezone selection to settings page

### DIFF
--- a/server-b/core/templates/core/settings.html
+++ b/server-b/core/templates/core/settings.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h1 class="text-xl font-bold mb-4">Settings</h1>
+<div class="space-y-2">
+  <label for="timezone-select" class="block text-sm font-medium text-gray-700">Timezone</label>
+  <select id="timezone-select" class="border rounded px-2 py-1"></select>
+</div>
+{% endblock %}

--- a/server-b/core/tests.py
+++ b/server-b/core/tests.py
@@ -1,3 +1,19 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+
+class SettingsTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username='user', password='pass')
+
+    def test_settings_page_has_timezone_select(self):
+        self.client.login(username='user', password='pass')
+        response = self.client.get(reverse('settings'))
+        self.assertContains(response, 'id="timezone-select"')
+
+    def test_dashboard_has_no_timezone_select(self):
+        self.client.login(username='user', password='pass')
+        response = self.client.get(reverse('dashboard'))
+        self.assertNotContains(response, 'id="timezone-select"')
+

--- a/server-b/core/urls.py
+++ b/server-b/core/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.dashboard, name='dashboard'),
+    path('settings/', views.settings, name='settings'),
 ]

--- a/server-b/core/views.py
+++ b/server-b/core/views.py
@@ -1,6 +1,12 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
+
 @login_required
 def dashboard(request):
     return render(request, 'core/dashboard.html')
+
+
+@login_required
+def settings(request):
+    return render(request, 'core/settings.html')

--- a/server-b/sms_gateway_project/templates/base.html
+++ b/server-b/sms_gateway_project/templates/base.html
@@ -46,7 +46,6 @@
         <a href="{% url 'dashboard' %}" class="text-[#111418] text-lg font-bold leading-tight tracking-[-0.015em]">SMS Gateway</a>
     </div>
     <div class="flex flex-1 items-center justify-end gap-8">
-        <select id="timezone-select" class="text-sm border rounded px-2 py-1"></select>
         {% if user.is_staff %}
         <a class="text-[#111418] text-sm font-bold leading-normal tracking-[0.015em]" href="{% url 'sms_provider_list' %}">Providers</a>
         {% endif %}
@@ -71,6 +70,7 @@
                 <a href="{% url 'user_update' user.pk %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Profile</a>
                 {% endif %}
                 <a href="{% url 'account_change_password' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Change Password</a>
+                <a href="{% url 'settings' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Settings</a>
                 <a href="{% url 'account_logout' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Logout</a>
             </div>
         </details>


### PR DESCRIPTION
## Summary
- remove timezone dropdown from header
- add dedicated settings page for timezone selection
- link settings page in user menu and add tests

## Testing
- `node tests/timezone.test.js`
- `pytest server-a` (failed: expected call not found; assert 401 == 202)
- `python server-b/manage.py test core`


------
https://chatgpt.com/codex/tasks/task_b_68b403243ccc832084ed63808e8e79f4