### PR TITLE
Fix toast messages repeating on message pages

### DIFF
--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -63,7 +63,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for message in messages %}
+                        {% for message in message_list %}
                         <tr>
                             <td><strong>{{ message.user.username }}</strong></td>
                             <td><strong>{{ message.recipient }}</strong></td>

--- a/server-b/messaging/templates/messaging/message_list.html
+++ b/server-b/messaging/templates/messaging/message_list.html
@@ -70,7 +70,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for message in messages %}
+                        {% for message in message_list %}
                         <tr>
                             <td><strong><a href="{% url 'messaging:message_detail' message.tracking_id %}">{{ message.recipient }}</a></strong></td>
                             <td>{{ message.text|truncatechars:50 }}</td>

--- a/server-b/messaging/tests.py
+++ b/server-b/messaging/tests.py
@@ -88,7 +88,7 @@ class UserMessageListViewTests(TestCase):
         self.client.login(username="user", password="pass")
         url = reverse("messaging:my_messages_list")
         response = self.client.get(url, {"tracking_id": "not-a-uuid"})
-        self.assertEqual(list(response.context["messages"]), [])
+        self.assertEqual(list(response.context["message_list"]), [])
 
     def test_awaiting_retry_shows_error_message(self):
         self.client.login(username="user", password="pass")

--- a/server-b/messaging/views.py
+++ b/server-b/messaging/views.py
@@ -7,7 +7,7 @@ import uuid
 class UserMessageListView(LoginRequiredMixin, ListView):
     model = Message
     template_name = 'messaging/message_list.html'
-    context_object_name = 'messages'
+    context_object_name = 'message_list'
     paginate_by = 25
 
     def get_queryset(self):
@@ -29,7 +29,7 @@ class UserMessageListView(LoginRequiredMixin, ListView):
 class AdminMessageListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
     model = Message
     template_name = 'messaging/admin_message_list.html'
-    context_object_name = 'messages'
+    context_object_name = 'message_list'
     paginate_by = 25
 
     def test_func(self):


### PR DESCRIPTION
## Summary
- avoid clobbering Django message storage by renaming context objects in message list views
- update message list templates to use the new `message_list` context
- adjust tests for updated context name

## Testing
- `cd server-b && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68b40688eed0832091d190d7a346f90f