### PR TITLE
Add robust tests for Server A components

### DIFF
--- a/server-a/tests/test_rabbit.py
+++ b/server-a/tests/test_rabbit.py
@@ -26,9 +26,10 @@ async def test_publish_sms_message_publishes_and_closes_connection():
     fixed_time = datetime(2023, 1, 1, 12, 0, 0)
 
     mock_channel = MagicMock()
-    mock_channel.declare_exchange = AsyncMock()
+    mock_exchange = MagicMock()
+    mock_exchange.publish = AsyncMock()
+    mock_channel.declare_exchange = AsyncMock(return_value=mock_exchange)
     mock_channel.declare_queue = AsyncMock()
-    mock_channel.publish = AsyncMock()
     mock_queue = MagicMock()
     mock_queue.bind = AsyncMock()
     mock_channel.declare_queue.return_value = mock_queue
@@ -76,9 +77,8 @@ async def test_publish_sms_message_publishes_and_closes_connection():
     assert kwargs["content_type"] == "application/json"
     assert kwargs["delivery_mode"] == aio_pika.DeliveryMode.PERSISTENT
 
-    mock_channel.publish.assert_called_once_with(
+    mock_exchange.publish.assert_awaited_once_with(
         mock_message.return_value,
-        exchange=RABBITMQ_EXCHANGE_NAME,
         routing_key=RABBITMQ_QUEUE_NAME,
     )
     mock_connection.close.assert_awaited_once()

--- a/tests/e2e/test_config_sync.py
+++ b/tests/e2e/test_config_sync.py
@@ -4,6 +4,10 @@ from uuid import uuid4
 
 import pytest
 import requests
+import shutil
+
+if not shutil.which("docker-compose"):
+    pytest.skip("docker-compose not installed", allow_module_level=True)
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
## Summary
- refine Server A send endpoint tests with dependency overrides and accurate settings
- ensure idempotency logic tests use correct TTL handling
- verify RabbitMQ publishing via exchange mock
- skip config sync e2e tests when docker-compose is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b695bc492083209b3794ee2ec4ec22