### PR TITLE
Add integration and end-to-end test automation

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,75 @@
+name: CI Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r server-b/requirements.txt
+      - name: Run Django tests
+        run: python server-b/manage.py test messaging
+
+  run-e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install test dependencies
+        run: pip install pytest requests
+      - name: Start services
+        run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up -d --build
+      - name: Wait for services
+        run: |
+          python - <<'PY'
+import time, requests
+start = time.time()
+url = 'http://localhost:8001/readyz'
+while time.time() - start < 60:
+    try:
+        if requests.get(url, timeout=5).status_code == 200:
+            break
+    except Exception:
+        pass
+    time.sleep(1)
+else:
+    raise SystemExit('Services did not become ready in time')
+PY
+      - name: Initialize test data
+        run: |
+          docker-compose exec -T server-b python manage.py shell <<'PY'
+from django.contrib.auth.models import User
+from user_management.models import Profile
+from providers.models import SmsProvider, AuthType
+from core.state_broadcaster import publish_full_state
+u, _ = User.objects.get_or_create(id=1, defaults={'username': 'bootstrap_user'})
+Profile.objects.update_or_create(user=u, defaults={'api_key': 'api_key_for_service_A', 'daily_quota': 1000})
+SmsProvider.objects.update_or_create(
+    slug='provider-a',
+    defaults={
+        'name': 'ProviderA',
+        'send_url': 'http://mock-provider-api:8000/send',
+        'balance_url': 'http://mock-provider-api:8000/balance',
+        'default_sender': '100',
+        'auth_type': AuthType.NONE,
+        'priority': 100,
+    },
+)
+publish_full_state()
+PY
+      - name: Run E2E tests
+        run: RUN_E2E=1 pytest tests/e2e/
+      - name: Teardown
+        if: always()
+        run: docker-compose -f docker-compose.yml -f docker-compose.test.yml down -v

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,6 @@
+services:
+  mock-provider-api:
+    build:
+      context: ./tests/mock_provider
+    ports:
+      - "5005:8000"

--- a/server-b/messaging/tests.py
+++ b/server-b/messaging/tests.py
@@ -10,7 +10,7 @@ django.setup()
 from celery.exceptions import Retry
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from messaging.models import Message, MessageStatus, MessageAttemptLog, AttemptStatus
@@ -498,6 +498,7 @@ class SendSmsWithFailoverTaskTests(TestCase):
         mock_publish.assert_called_once_with(self.message)
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class SmsSendFlowTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user("user", password="pass")

--- a/tests/e2e/test_config_sync.py
+++ b/tests/e2e/test_config_sync.py
@@ -1,33 +1,15 @@
+import os
 import subprocess
 import time
 from uuid import uuid4
 
 import pytest
 import requests
-import shutil
 
-if not shutil.which("docker-compose"):
-    pytest.skip("docker-compose not installed", allow_module_level=True)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def compose_environment():
-    """Spin up the docker-compose environment for the test module."""
-    subprocess.run(["docker-compose", "up", "-d", "--build"], check=True)
-    # Wait for services to come up
-    start = time.time()
-    while time.time() - start < 60:
-        try:
-            resp = requests.get("http://localhost:8001/readyz", timeout=5)
-            if resp.status_code == 200:
-                break
-        except Exception:
-            pass
-        time.sleep(1)
-    else:
-        raise RuntimeError("Services did not become ready in time")
-    yield
-    subprocess.run(["docker-compose", "down", "-v"], check=True)
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1",
+    reason="E2E tests require docker-compose environment",
+)
 
 
 def _send_request(provider_name: str) -> requests.Response:

--- a/tests/e2e/test_sms_flow.py
+++ b/tests/e2e/test_sms_flow.py
@@ -1,8 +1,7 @@
-import json
 import os
 import subprocess
 import time
-
+import json
 import pytest
 import requests
 
@@ -10,25 +9,6 @@ pytestmark = pytest.mark.skipif(
     os.environ.get("RUN_E2E") != "1",
     reason="E2E tests require docker-compose environment",
 )
-
-
-@pytest.fixture(scope="module", autouse=True)
-def compose_environment():
-    subprocess.run(["docker-compose", "up", "-d", "--build"], check=True)
-    start = time.time()
-    while time.time() - start < 60:
-        try:
-            resp = requests.get("http://localhost:8001/readyz", timeout=5)
-            if resp.status_code == 200:
-                break
-        except Exception:
-            pass
-        time.sleep(1)
-    else:
-        subprocess.run(["docker-compose", "down", "-v"], check=False)
-        raise RuntimeError("Services did not become ready in time")
-    yield
-    subprocess.run(["docker-compose", "down", "-v"], check=True)
 
 
 def _send_request():

--- a/tests/mock_provider/Dockerfile
+++ b/tests/mock_provider/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY app.py /app/app.py
+RUN pip install fastapi uvicorn
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tests/mock_provider/app.py
+++ b/tests/mock_provider/app.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI()
+
+MODE = "success"
+REQUEST_LOGS: List[dict] = []
+
+class ConfigMode(BaseModel):
+    mode: str
+
+@app.post("/config")
+def set_mode(cfg: ConfigMode):
+    global MODE, REQUEST_LOGS
+    MODE = cfg.mode
+    REQUEST_LOGS = []
+    return {"mode": MODE}
+
+@app.get("/logs")
+def get_logs():
+    return REQUEST_LOGS
+
+@app.post("/send")
+async def send(request: Request):
+    payload = await request.json()
+    REQUEST_LOGS.append(payload)
+    if MODE == "success":
+        return {"status": 0, "messages": [{"id": 1, "status": 0}]}
+    if MODE == "transient":
+        raise HTTPException(status_code=503, detail="temporary failure")
+    if MODE == "permanent":
+        return {"status": 1, "messages": [{"id": 1, "status": 1}]}
+    return {"status": 0, "messages": [{"id": 1, "status": 0}]}


### PR DESCRIPTION
## Summary
- ensure Django failover tests run eagerly and cover happy path, failover, retry, fail-fast, and provider order scenarios
- add mock SMS provider and docker-compose test stack for E2E testing
- introduce GitHub Actions workflow to run integration and E2E suites

## Testing
- `python server-b/manage.py test messaging`
- `pytest tests/e2e/test_sms_flow.py`
- `pytest tests/e2e/test_config_sync.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7b77df0e08320a99af64e73c9c932