### PR TITLE
Feature/support_vhost

### DIFF
--- a/server-a/.env.example
+++ b/server-a/.env.example
@@ -20,6 +20,9 @@ RABBITMQ_HOST=rabbitmq
 RABBITMQ_PORT=5672
 RABBITMQ_USER=guest
 RABBITMQ_PASS=guest
+RABBITMQ_VHOST=/
+RABBITMQ_EXCHANGE=sms_gateway_exchange
+RABBITMQ_ROUTING_KEY=sms_outbound_queue
 
 
 # -- Application Logic Settings --

--- a/server-a/app/config.py
+++ b/server-a/app/config.py
@@ -29,8 +29,10 @@ class Settings:
         self.rabbit_port: int = int(os.getenv("RABBITMQ_PORT", "5672"))
         self.rabbit_user: str = os.getenv("RABBITMQ_USER", "guest")
         self.rabbit_pass: str = os.getenv("RABBITMQ_PASS", "guest")
-        self.outbound_sms_exchange: str = os.getenv("OUTBOUND_SMS_EXCHANGE", "sms_outbound_exchange")
+        self.rabbit_vhost: str = os.getenv("RABBITMQ_VHOST", "/")
+        self.outbound_sms_exchange: str = os.getenv("RABBITMQ_EXCHANGE", "sms_gateway_exchange")
         self.outbound_sms_queue: str = os.getenv("OUTBOUND_SMS_QUEUE", "sms_outbound_queue")
+        self.outbound_sms_routing_key: str = os.getenv("RABBITMQ_ROUTING_KEY", self.outbound_sms_queue)
         self.idempotency_ttl_seconds: int = int(os.getenv("IDEMPOTENCY_TTL_SECONDS", "86400"))
         self.heartbeat_interval_seconds: int = int(os.getenv("HEARTBEAT_INTERVAL_SECONDS", "60"))
         self.PROVIDER_GATE_ENABLED: bool = os.getenv("PROVIDER_GATE_ENABLED", "True").lower() in ("true", "1", "t")
@@ -45,7 +47,8 @@ class Settings:
     def RABBITMQ_URL(self) -> str:
         if hasattr(self, '_RABBITMQ_URL'):
             return self._RABBITMQ_URL
-        return f"amqp://{self.rabbit_user}:{self.rabbit_pass}@{self.rabbit_host}:{self.rabbit_port}/"
+        vhost = self.rabbit_vhost if self.rabbit_vhost.startswith('/') else f"/{self.rabbit_vhost}"
+        return f"amqp://{self.rabbit_user}:{self.rabbit_pass}@{self.rabbit_host}:{self.rabbit_port}{vhost}"
 
     @RABBITMQ_URL.setter
     def RABBITMQ_URL(self, value):

--- a/server-a/app/main.py
+++ b/server-a/app/main.py
@@ -66,8 +66,8 @@ async def lifespan(app: FastAPI):
     try:
         rabbitmq_connection = await get_rabbitmq_connection()
         rabbitmq_channel = await rabbitmq_connection.channel()
-        await rabbitmq_channel.declare_exchange(RABBITMQ_EXCHANGE_NAME, aio_pika.ExchangeType.DIRECT, durable=True)
-        await rabbitmq_channel.declare_queue(RABBITMQ_QUEUE_NAME, durable=True)
+        await rabbitmq_channel.declare_exchange(settings.outbound_sms_exchange, aio_pika.ExchangeType.DIRECT, durable=True)
+        await rabbitmq_channel.declare_queue(settings.outbound_sms_queue, durable=True)
         await rabbitmq_channel.declare_exchange(HEARTBEAT_EXCHANGE_NAME, aio_pika.ExchangeType.DIRECT, durable=True)
         await rabbitmq_channel.declare_queue(HEARTBEAT_QUEUE_NAME, durable=True)
         logger.info("RabbitMQ connection and channel initialized.")


### PR DESCRIPTION
The `test_publish_sms_message_publishes_and_closes_connection` test now patches `RABBITMQ_EXCHANGE_NAME`, `RABBITMQ_QUEUE_NAME`, and `RABBITMQ_ROUTING_KEY` directly within its scope.

This change improves test isolation and robustness. By patching these constants, the test no longer depends on their specific values defined in `app.rabbit`. Instead, it verifies that the `publish_sms_message` function correctly uses the provided exchange, queue, and routing key, making the test less brittle to changes in the application's constant definitions.