### PR TITLE
Fix allauth signup field configuration

### DIFF
--- a/server-b/sms_gateway_project/settings.py
+++ b/server-b/sms_gateway_project/settings.py
@@ -146,7 +146,8 @@ ACCOUNT_LOGOUT_REDIRECT_URL = '/'
 ACCOUNT_LOGIN_METHODS = ['username']
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_ALLOW_REGISTRATION = False
-ACCOUNT_SIGNUP_FIELDS = ['username', 'password']
+# Use ``*`` to mark required fields per django-allauth's SIGNUP_FIELDS format.
+ACCOUNT_SIGNUP_FIELDS = ['username*', 'password1*']
 ACCOUNT_RATE_LIMITS = {
     'login_failed': '5/5m',
 }


### PR DESCRIPTION
## Summary
- mark allauth signup fields with the required `*` suffix and use `password1`
- keep username-based logins valid by aligning signup field requirements with django-allauth checks

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_b_68ca2f1eb82c8330b3a4913796e17b44