### PR TITLE
Add admin export for user and provider config

### DIFF
--- a/server-b/user_management/templates/user_management/user_list.html
+++ b/server-b/user_management/templates/user_management/user_list.html
@@ -13,7 +13,12 @@
                 <h1 class="title">User Management</h1>
                 <p class="subtitle">Manage users and their access levels.</p>
             </div>
-            <a href="{% url 'user_create' %}" class="btn btn-primary">Add user</a>
+            <div class="actions">
+                <a href="{% url 'config_export' %}" class="btn" download>
+                    Download config
+                </a>
+                <a href="{% url 'user_create' %}" class="btn btn-primary">Add user</a>
+            </div>
         </div>
 
         <!-- Card -->

--- a/server-b/user_management/tests.py
+++ b/server-b/user_management/tests.py
@@ -1,6 +1,10 @@
+import json
+
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
-from django.contrib.auth.models import User
+
+from providers.models import AuthType, ProviderType, SmsProvider
 
 
 class UserToggleActiveViewTests(TestCase):
@@ -33,3 +37,55 @@ class UserUpdateViewTests(TestCase):
         self.assertTemplateUsed(response, "user_management/user_form.html")
         form = response.context["form"]
         self.assertEqual(form.instance, self.user)
+
+
+class ConfigExportViewTests(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user("admin", "admin@example.com", "pass")
+        self.staff.is_staff = True
+        self.staff.save()
+        self.staff.profile.api_key = "staff-key"
+        self.staff.profile.daily_quota = 10
+        self.staff.profile.save()
+
+        self.user = User.objects.create_user("user", "user@example.com", "pass")
+        self.user.profile.api_key = "user-key"
+        self.user.profile.daily_quota = 5
+        self.user.profile.save()
+
+        self.provider = SmsProvider.objects.create(
+            name="Magfa",
+            slug="magfa",
+            send_url="http://example.com/send",
+            balance_url="http://example.com/balance",
+            default_sender="100",
+            auth_type=AuthType.NONE,
+            provider_type=ProviderType.MAGFA,
+        )
+
+    def test_staff_can_download_config_file(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("config_export"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response["Content-Type"].startswith("application/json"))
+        self.assertIn("config_cache.json", response["Content-Disposition"])
+
+        payload = json.loads(response.content.decode("utf-8"))
+        self.assertIn("users", payload)
+        self.assertIn("providers", payload)
+        self.assertIn("user-key", payload["users"])
+        self.assertEqual(payload["users"]["user-key"]["user_id"], self.user.id)
+
+        provider_data = payload["providers"].get(self.provider.name)
+        self.assertIsNotNone(provider_data)
+        self.assertTrue(provider_data["is_active"])
+        self.assertIn(self.provider.slug, provider_data["aliases"])
+
+    def test_non_staff_user_is_forbidden(self):
+        non_staff = User.objects.create_user("viewer", "viewer@example.com", "pass")
+        non_staff.profile.api_key = "viewer-key"
+        non_staff.profile.save()
+        self.client.force_login(non_staff)
+
+        response = self.client.get(reverse("config_export"))
+        self.assertEqual(response.status_code, 403)

--- a/server-b/user_management/urls.py
+++ b/server-b/user_management/urls.py
@@ -1,16 +1,18 @@
 from django.urls import path
 from .views import (
-    UserListView,
-    UserCreateView,
-    UserUpdateView,
-    UserDeleteView,
+    ConfigExportView,
     ToggleUserStatusView,
+    UserCreateView,
+    UserDeleteView,
+    UserListView,
     UserPasswordChangeView,
+    UserUpdateView,
 )
 
 urlpatterns = [
     path('users/', UserListView.as_view(), name='user_list'),
     path('users/create/', UserCreateView.as_view(), name='user_create'),
+    path('users/export-config/', ConfigExportView.as_view(), name='config_export'),
     path('users/<int:pk>/update/', UserUpdateView.as_view(), name='user_update'),
     path('users/<int:pk>/delete/', UserDeleteView.as_view(), name='user_delete'),
     path('users/<int:pk>/toggle_status/', ToggleUserStatusView.as_view(), name='user_toggle'),


### PR DESCRIPTION
## Summary
- add a staff-only view that exports user and provider configuration as JSON for Server A
- expose the export via a download button on the user management screen
- add unit tests covering the export payload and permission checks

## Testing
- python manage.py test user_management

------
https://chatgpt.com/codex/tasks/task_b_68ce66ba1dd48330a8800ec1bcdb4923