### PR TITLE
Add consolidated My Profile page

### DIFF
--- a/server-b/core/templates/core/settings.html
+++ b/server-b/core/templates/core/settings.html
@@ -1,9 +1,0 @@
-{% extends 'base.html' %}
-
-{% block content %}
-<h1 class="text-xl font-bold mb-4">Settings</h1>
-<div class="space-y-2">
-  <label for="timezone-select" class="block text-sm font-medium text-gray-700">Timezone</label>
-  <select id="timezone-select" class="border rounded px-2 py-1"></select>
-</div>
-{% endblock %}

--- a/server-b/core/urls.py
+++ b/server-b/core/urls.py
@@ -11,5 +11,4 @@ urlpatterns = [
         ),
     ),
     path('docs/server-a/', views.server_a_user_guide, name='server_a_user_guide'),
-    path('settings/', views.settings, name='settings'),
 ]

--- a/server-b/core/views.py
+++ b/server-b/core/views.py
@@ -6,7 +6,3 @@ from django.contrib.auth.decorators import login_required
 def server_a_user_guide(request):
     return render(request, 'core/server_a_user_guide.html')
 
-
-@login_required
-def settings(request):
-    return render(request, 'core/settings.html')

--- a/server-b/sms_gateway_project/templates/base.html
+++ b/server-b/sms_gateway_project/templates/base.html
@@ -67,11 +67,8 @@
                 </div>
             </summary>
             <div class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
-                {% if user.is_staff %}
-                <a href="{% url 'user_update' user.pk %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Profile</a>
-                {% endif %}
+                <a href="{% url 'my_profile' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">My Profile</a>
                 <a href="{% url 'account_change_password' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Change Password</a>
-                <a href="{% url 'settings' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Settings</a>
                 <a href="{% url 'account_logout' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Logout</a>
             </div>
         </details>

--- a/server-b/user_management/templates/user_management/my_profile.html
+++ b/server-b/user_management/templates/user_management/my_profile.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="space-y-10">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <h1 class="text-3xl font-bold text-slate-900">My Profile</h1>
+      <p class="mt-1 text-sm text-slate-600">Review your account details and personal preferences.</p>
+    </div>
+    <a
+      href="{% url 'account_change_password' %}"
+      class="inline-flex items-center justify-center rounded-lg bg-brand-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-900/60"
+    >
+      Change Password
+    </a>
+  </div>
+
+  <div class="grid gap-6 lg:grid-cols-2">
+    <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-slate-900">Account Information</h2>
+      <dl class="mt-4 space-y-4">
+        <div>
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Username</dt>
+          <dd class="mt-1 text-base text-slate-900">{{ user.username }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Email</dt>
+          <dd class="mt-1 text-base text-slate-900">{{ user.email|default:"Not provided" }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">API Key</dt>
+          <dd class="mt-1 break-all text-base text-slate-900">{{ profile_api_key|default:"Not set" }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Daily Quota</dt>
+          <dd class="mt-1 text-base text-slate-900">{{ profile_daily_quota }}</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-slate-900">Timezone</h2>
+      <p class="mt-2 text-sm text-slate-600">Select your preferred timezone to view message timestamps in your local time.</p>
+      <label for="timezone-select" class="mt-4 block text-sm font-medium text-slate-700">Timezone</label>
+      <select id="timezone-select" class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-brand-900 focus:outline-none focus:ring-2 focus:ring-brand-900/40"></select>
+    </section>
+  </div>
+</div>
+{% endblock %}

--- a/server-b/user_management/urls.py
+++ b/server-b/user_management/urls.py
@@ -7,9 +7,11 @@ from .views import (
     UserListView,
     UserPasswordChangeView,
     UserUpdateView,
+    my_profile,
 )
 
 urlpatterns = [
+    path('profile/', my_profile, name='my_profile'),
     path('users/', UserListView.as_view(), name='user_list'),
     path('users/create/', UserCreateView.as_view(), name='user_create'),
     path('users/export-config/', ConfigExportView.as_view(), name='config_export'),

--- a/server-b/user_management/views.py
+++ b/server-b/user_management/views.py
@@ -1,12 +1,13 @@
 import json
 
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm, SetPasswordForm
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.models import User
 from django.contrib.auth.views import PasswordChangeView
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -159,3 +160,16 @@ class UserPasswordChangeView(StaffRequiredMixin, PasswordChangeView):
             self.request, "Error changing user password. Please check the form."
         )
         return super().form_invalid(form)
+
+
+@login_required
+def my_profile(request):
+    user = request.user
+    profile = getattr(user, "profile", None)
+
+    context = {
+        "profile_api_key": getattr(profile, "api_key", ""),
+        "profile_daily_quota": getattr(profile, "daily_quota", 0),
+    }
+
+    return render(request, "user_management/my_profile.html", context)


### PR DESCRIPTION
## Summary
- add a dedicated My Profile view that surfaces the signed-in user's account details alongside quota and API key information
- move the timezone selector into the profile template and highlight the change-password action
- update navigation to link to the new profile page for all users and remove the legacy settings view/URL

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_b_68d0fa8ba90083308e314ef327240a98