### PR TITLE
Gracefully cancel heartbeat and consumer tasks on shutdown

### DIFF
--- a/server-a/tests/test_config_state_consumer.py
+++ b/server-a/tests/test_config_state_consumer.py
@@ -35,17 +35,18 @@ def test_config_sync_enabled_default_true(reset_settings):
 def test_start_consumer_disabled(monkeypatch, caplog, reset_settings):
     created_tasks = []
 
-    def fake_create_task(coro):
-        created_tasks.append(coro)
+    def fake_create_task(coro, *args, **kwargs):
+        created_tasks.append((coro, kwargs))
         return object()
 
     monkeypatch.setattr(asyncio, "create_task", fake_create_task)
     monkeypatch.setattr(main.settings, "CONFIG_STATE_SYNC_ENABLED", False)
 
     with caplog.at_level("INFO"):
-        main.start_config_state_consumer_if_enabled()
+        task = main.start_config_state_consumer_if_enabled()
 
     assert created_tasks == []
+    assert task is None
     assert "Remote configuration sync disabled" in caplog.text
 
 
@@ -53,21 +54,26 @@ def test_start_consumer_enabled(monkeypatch, caplog, reset_settings):
     dummy_consumer = _DummyConsumer()
     created_tasks = []
 
-    def fake_create_task(coro):
-        created_tasks.append(coro)
-        return object()
+    fake_task = object()
+
+    def fake_create_task(coro, *args, **kwargs):
+        created_tasks.append((coro, kwargs))
+        return fake_task
 
     monkeypatch.setattr(asyncio, "create_task", fake_create_task)
     monkeypatch.setattr(main, "consume_config_state", dummy_consumer)
     monkeypatch.setattr(main.settings, "CONFIG_STATE_SYNC_ENABLED", True)
 
     with caplog.at_level("INFO"):
-        main.start_config_state_consumer_if_enabled()
+        task = main.start_config_state_consumer_if_enabled()
 
     assert dummy_consumer.called == 1
     assert len(created_tasks) == 1
-    assert created_tasks[0] is dummy_consumer.coros[0]
+    coro, kwargs = created_tasks[0]
+    assert coro is dummy_consumer.coros[0]
+    assert kwargs.get("name") == "config-state-consumer"
+    assert task is fake_task
     assert "Configuration state consumer started" in caplog.text
 
-    for coro in created_tasks:
+    for coro, _ in created_tasks:
         coro.close()

--- a/server-a/tests/test_health_readiness.py
+++ b/server-a/tests/test_health_readiness.py
@@ -1,8 +1,10 @@
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 from fastapi import FastAPI, status, HTTPException
 from httpx import AsyncClient
 
+import app.main as main
 from app.main import app, readyz, healthz # Import the endpoints
 from app.config import Settings
 
@@ -77,7 +79,62 @@ async def test_readyz_endpoint_rabbitmq_unreachable(test_app_with_mocked_lifespa
     with patch('app.main.rabbitmq_connection.is_closed', True):
         async with AsyncClient(app=test_app_with_mocked_lifespan, base_url="http://test") as client:
             response = await client.get("/readyz")
-        
+
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
         assert response.json()["error_code"] == "SERVICE_UNAVAILABLE"
         assert "RabbitMQ not connected" in response.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_lifespan_cancels_background_tasks(monkeypatch):
+    heartbeat_started = asyncio.Event()
+    heartbeat_cancelled = asyncio.Event()
+    consumer_started = asyncio.Event()
+    consumer_cancelled = asyncio.Event()
+
+    async def heartbeat_stub():
+        heartbeat_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            heartbeat_cancelled.set()
+            raise
+
+    async def consume_stub():
+        consumer_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            consumer_cancelled.set()
+            raise
+
+    mock_redis_client = AsyncMock()
+    mock_redis_client.ping = AsyncMock(return_value=True)
+    mock_redis_client.close = AsyncMock()
+
+    mock_channel = AsyncMock()
+    mock_channel.declare_exchange = AsyncMock()
+    mock_channel.declare_queue = AsyncMock()
+
+    mock_rabbitmq_connection = AsyncMock()
+    mock_rabbitmq_connection.channel = AsyncMock(return_value=mock_channel)
+    mock_rabbitmq_connection.close = AsyncMock()
+
+    monkeypatch.setattr(main, "redis_client", None)
+    monkeypatch.setattr(main, "rabbitmq_connection", None)
+    monkeypatch.setattr(main, "rabbitmq_channel", None)
+    monkeypatch.setattr(main, "get_redis_client", AsyncMock(return_value=mock_redis_client))
+    monkeypatch.setattr(main, "get_rabbitmq_connection", AsyncMock(return_value=mock_rabbitmq_connection))
+    monkeypatch.setattr(main, "start_heartbeat_task", heartbeat_stub)
+    monkeypatch.setattr(main, "consume_config_state", consume_stub)
+    monkeypatch.setattr(main.settings, "CONFIG_STATE_SYNC_ENABLED", True, raising=False)
+    monkeypatch.setattr(main, "load_state_from_file", MagicMock(return_value=True))
+
+    async with app.router.lifespan_context(app):
+        await asyncio.wait_for(heartbeat_started.wait(), timeout=1)
+        await asyncio.wait_for(consumer_started.wait(), timeout=1)
+
+    assert heartbeat_cancelled.is_set()
+    assert consumer_cancelled.is_set()
+    mock_rabbitmq_connection.close.assert_awaited_once()
+    mock_redis_client.close.assert_awaited_once()


### PR DESCRIPTION
## Summary
- make the heartbeat loop cancellation-aware so it can stop cleanly during shutdown
- track background tasks created during startup and cancel/await them when the FastAPI lifespan ends
- extend the test suite to cover background task management and heartbeat task cancellation

## Testing
- pytest server-a/tests

------
https://chatgpt.com/codex/tasks/task_b_68d36a651c2c83309d010539bda5b6c4