### PR TITLE
Normalize Magfa cost storage and add currency filter

### DIFF
--- a/server-b/messaging/templates/messaging/message_detail.html
+++ b/server-b/messaging/templates/messaging/message_detail.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load messaging_time %}
+{% load messaging_extras %}
 
 {% block content %}
 <div class="flex flex-col gap-8">
@@ -51,7 +52,7 @@
                 </div>
                 <div class="flex flex-col gap-1">
                     <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Cost</dt>
-                    <dd class="text-base font-medium text-slate-900">{{ object.cost|default:"N/A" }}</dd>
+                    <dd class="text-base font-medium text-slate-900">{{ object.cost|format_currency }}</dd>
                 </div>
             </dl>
         </div>

--- a/server-b/messaging/templatetags/messaging_extras.py
+++ b/server-b/messaging/templatetags/messaging_extras.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def format_currency(value):
+    """Format a Rial-based amount for display in Tomans with an IRT suffix."""
+
+    if value in (None, ""):
+        return "N/A"
+
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return "N/A"
+
+    toman_value = amount / Decimal("10")
+
+    if toman_value == toman_value.to_integral_value():
+        formatted_number = f"{int(toman_value):,}"
+    else:
+        rounded_value = toman_value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        formatted_number = f"{rounded_value:,}"
+
+    return f"{formatted_number} IRT"

--- a/server-b/providers/adapters.py
+++ b/server-b/providers/adapters.py
@@ -86,6 +86,7 @@ class MagfaSmsProvider(BaseSmsProvider):
                 'status': 'success',
                 'message_id': provider_message_id,
                 'raw_response': data,
+                # // The 'tariff' from Magfa is in Rials, which is our base unit. No conversion needed.
                 'cost': cost,
             }
         if status_code in (1, 27, 33):


### PR DESCRIPTION
## Summary
- ensure the Magfa adapter explicitly returns the provider tariff as the stored cost with documentation inline
- add a reusable `format_currency` template filter that converts stored Rial amounts to display-friendly Tomans
- update the message detail template to load the new filter and present costs consistently with the IRT suffix

## Testing
- pytest *(fails: `server-b/tests/test_messaging_tasks.py::test_update_delivery_statuses_updates_recent_messages` due to timezone expectation mismatch in the existing suite)*

------
https://chatgpt.com/codex/tasks/task_b_68d8db741cb8833095c6e54020ea68cf