### PR TITLE
Improve styling of change password inputs

### DIFF
--- a/server-b/sms_gateway_project/templates/account/password_change.html
+++ b/server-b/sms_gateway_project/templates/account/password_change.html
@@ -35,8 +35,15 @@
 
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div class="md:col-span-2">
-                            {{ form.oldpassword.label_tag }}
-                            {{ form.oldpassword }}
+                            <label for="{{ form.oldpassword.id_for_label }}" class="label">{{ form.oldpassword.label }}</label>
+                            <input
+                                type="{{ form.oldpassword.field.widget.input_type }}"
+                                name="{{ form.oldpassword.html_name }}"
+                                id="{{ form.oldpassword.id_for_label }}"
+                                class="input"
+                                autocomplete="current-password"
+                                required
+                            >
                             {% if form.oldpassword.help_text %}
                                 <p class="subtitle">{{ form.oldpassword.help_text }}</p>
                             {% endif %}
@@ -45,8 +52,15 @@
                             {% endfor %}
                         </div>
                         <div>
-                            {{ form.password1.label_tag }}
-                            {{ form.password1 }}
+                            <label for="{{ form.password1.id_for_label }}" class="label">{{ form.password1.label }}</label>
+                            <input
+                                type="{{ form.password1.field.widget.input_type }}"
+                                name="{{ form.password1.html_name }}"
+                                id="{{ form.password1.id_for_label }}"
+                                class="input"
+                                autocomplete="new-password"
+                                required
+                            >
                             {% if form.password1.help_text %}
                                 <p class="subtitle">{{ form.password1.help_text }}</p>
                             {% endif %}
@@ -55,8 +69,15 @@
                             {% endfor %}
                         </div>
                         <div>
-                            {{ form.password2.label_tag }}
-                            {{ form.password2 }}
+                            <label for="{{ form.password2.id_for_label }}" class="label">{{ form.password2.label }}</label>
+                            <input
+                                type="{{ form.password2.field.widget.input_type }}"
+                                name="{{ form.password2.html_name }}"
+                                id="{{ form.password2.id_for_label }}"
+                                class="input"
+                                autocomplete="new-password"
+                                required
+                            >
                             {% if form.password2.help_text %}
                                 <p class="subtitle">{{ form.password2.help_text }}</p>
                             {% endif %}


### PR DESCRIPTION
## Summary
- apply the dashboard input styling to the account password change form
- render explicit labels and inputs so the UI matches the rest of the dashboard

## Testing
- python manage.py migrate


------
https://chatgpt.com/codex/tasks/task_b_68d8e313ce58833086a913abb0871a11