### PR TITLE
Add cost column to admin messages list

### DIFF
--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
-{% load pagination_tags %}
+{% load pagination_tags messaging_currency %}
 
 {% block extra_head %}
     <link rel="stylesheet" href="{% static 'css/dashboard.css' %}">
@@ -65,6 +65,7 @@
                             <th>Text</th>
                             <th>Status</th>
                             <th>Provider</th>
+                            <th>Cost (IRT)</th>
                             <th>Date Sent</th>
                         </tr>
                     </thead>
@@ -81,13 +82,14 @@
                                 {% endif %}
                             </td>
                             <td>{{ message.provider.name }}</td>
+                            <td>{{ message.cost|rial_to_toman|default:"N/A" }}</td>
                             {% with timestamp=message.delivered_at|default:message.sent_at|default:message.created_at %}
                                 <td class="utc-time" data-utc="{{ timestamp|date:'c' }}"></td>
                             {% endwith %}
                         </tr>
                         {% empty %}
                         <tr>
-                            <td colspan="6">No messages found.</td>
+                            <td colspan="7">No messages found.</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/server-b/messaging/tests.py
+++ b/server-b/messaging/tests.py
@@ -1148,6 +1148,28 @@ class AdminMessageListViewTests(TestCase):
         detail_url = reverse("messaging:admin_message_detail", args=[self.message.tracking_id])
         self.assertContains(response, detail_url)
 
+    def test_cost_column_displays_toman_amount(self):
+        self.message.cost = Decimal("25000")
+        self.message.save(update_fields=["cost"])
+
+        self.client.login(username="admin", password="pass")
+        url = reverse("messaging:admin_messages_list")
+        response = self.client.get(url)
+
+        self.assertContains(response, "<th>Cost (IRT)</th>", html=True)
+        self.assertContains(response, "<td>2500</td>", html=True)
+
+    def test_cost_column_shows_na_when_unavailable(self):
+        self.message.cost = None
+        self.message.save(update_fields=["cost"])
+
+        self.client.login(username="admin", password="pass")
+        url = reverse("messaging:admin_messages_list")
+        response = self.client.get(url)
+
+        self.assertContains(response, "<th>Cost (IRT)</th>", html=True)
+        self.assertContains(response, "<td>N/A</td>", html=True)
+
     def test_status_pill_and_timestamp_use_delivery_information(self):
         delivered_at = timezone.now().replace(microsecond=0)
         sent_at = delivered_at - timedelta(minutes=10)


### PR DESCRIPTION
## Summary
- display message costs on the admin messages list in IRT
- ensure missing costs render as N/A while keeping currency conversions consistent
- add regression tests covering the new cost column behaviour

## Testing
- python server-b/manage.py test messaging.tests.AdminMessageListViewTests

------
https://chatgpt.com/codex/tasks/task_e_68da32995e388324b1e38ab81867e779