### PR TITLE
Add advanced filtering to admin message list view

### DIFF
--- a/server-b/messaging/forms.py
+++ b/server-b/messaging/forms.py
@@ -8,28 +8,70 @@ from providers.models import SmsProvider
 from .models import MessageStatus
 
 
+class DatePickerInput(forms.DateInput):
+    input_type = "date"
+
+
 class MessageFilterForm(forms.Form):
-    username = forms.CharField(required=False, label="Username")
+    username = forms.CharField(
+        required=False,
+        label="Username",
+        widget=forms.TextInput(
+            attrs={
+                "class": "input",
+                "placeholder": "Search username",
+                "autocomplete": "off",
+            }
+        ),
+    )
     status = forms.ChoiceField(
         required=False,
-        choices=[("", "---------")] + list(MessageStatus.choices),
+        choices=list(MessageStatus.choices),
         label="Status",
+        widget=forms.Select(
+            attrs={
+                "class": "input",
+            }
+        ),
     )
     provider = forms.ModelChoiceField(
         queryset=SmsProvider.objects.all(),
         required=False,
         label="Provider",
+        widget=forms.Select(
+            attrs={
+                "class": "input",
+            }
+        ),
     )
     date_from = forms.DateField(
         required=False,
-        widget=forms.DateInput(attrs={"type": "date"}),
+        widget=DatePickerInput(
+            attrs={
+                "class": "input",
+                "placeholder": "From",
+            }
+        ),
         label="From date",
     )
     date_to = forms.DateField(
         required=False,
-        widget=forms.DateInput(attrs={"type": "date"}),
+        widget=DatePickerInput(
+            attrs={
+                "class": "input",
+                "placeholder": "To",
+            }
+        ),
         label="To date",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["status"].choices = [
+            ("", "All statuses"),
+            *MessageStatus.choices,
+        ]
+        self.fields["provider"].empty_label = "All providers"
 
     def clean_status(self):
         status = self.cleaned_data.get("status")

--- a/server-b/messaging/forms.py
+++ b/server-b/messaging/forms.py
@@ -94,3 +94,16 @@ class MessageFilterForm(forms.Form):
         if timezone.is_naive(end):
             end = timezone.make_aware(end, timezone.get_current_timezone())
         return end
+
+    def get_active_filters(self):
+        if not self.is_bound:
+            return {}
+        if not self.is_valid():
+            return {}
+
+        active = {}
+        for field_name in ["username", "status", "provider", "date_from", "date_to"]:
+            value = self.cleaned_data.get(field_name)
+            if value:
+                active[field_name] = value
+        return active

--- a/server-b/messaging/forms.py
+++ b/server-b/messaging/forms.py
@@ -1,0 +1,54 @@
+from datetime import datetime, time
+
+from django import forms
+from django.utils import timezone
+
+from providers.models import SmsProvider
+
+from .models import MessageStatus
+
+
+class MessageFilterForm(forms.Form):
+    username = forms.CharField(required=False, label="Username")
+    status = forms.ChoiceField(
+        required=False,
+        choices=[("", "---------")] + list(MessageStatus.choices),
+        label="Status",
+    )
+    provider = forms.ModelChoiceField(
+        queryset=SmsProvider.objects.all(),
+        required=False,
+        label="Provider",
+    )
+    date_from = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}),
+        label="From date",
+    )
+    date_to = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}),
+        label="To date",
+    )
+
+    def clean_status(self):
+        status = self.cleaned_data.get("status")
+        return status or None
+
+    def get_date_from_datetime(self):
+        date_from = self.cleaned_data.get("date_from")
+        if not date_from:
+            return None
+        start = datetime.combine(date_from, time.min)
+        if timezone.is_naive(start):
+            start = timezone.make_aware(start, timezone.get_current_timezone())
+        return start
+
+    def get_date_to_datetime(self):
+        date_to = self.cleaned_data.get("date_to")
+        if not date_to:
+            return None
+        end = datetime.combine(date_to, time.max)
+        if timezone.is_naive(end):
+            end = timezone.make_aware(end, timezone.get_current_timezone())
+        return end

--- a/server-b/messaging/forms.py
+++ b/server-b/messaging/forms.py
@@ -1,6 +1,7 @@
 from datetime import datetime, time
 
 from django import forms
+from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from providers.models import SmsProvider
@@ -8,19 +9,29 @@ from providers.models import SmsProvider
 from .models import MessageStatus
 
 
+User = get_user_model()
+
+
 class DatePickerInput(forms.DateInput):
     input_type = "date"
 
 
+class UserChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        full_name = obj.get_full_name()
+        if full_name:
+            return f"{full_name} ({obj.username})"
+        return obj.username
+
+
 class MessageFilterForm(forms.Form):
-    username = forms.CharField(
+    user = UserChoiceField(
+        queryset=User.objects.none(),
         required=False,
-        label="Username",
-        widget=forms.TextInput(
+        label="User",
+        widget=forms.Select(
             attrs={
                 "class": "input",
-                "placeholder": "Search username",
-                "autocomplete": "off",
             }
         ),
     )
@@ -67,6 +78,8 @@ class MessageFilterForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["user"].queryset = User.objects.order_by("username")
+        self.fields["user"].empty_label = "All users"
         self.fields["status"].choices = [
             ("", "All statuses"),
             *MessageStatus.choices,
@@ -102,7 +115,7 @@ class MessageFilterForm(forms.Form):
             return {}
 
         active = {}
-        for field_name in ["username", "status", "provider", "date_from", "date_to"]:
+        for field_name in ["user", "status", "provider", "date_from", "date_to"]:
             value = self.cleaned_data.get(field_name)
             if value:
                 active[field_name] = value

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -89,18 +89,31 @@
         }
         .filters-panel__fields {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            grid-template-columns: repeat(12, minmax(0, 1fr));
             gap: 1rem;
         }
         .filters-panel__field {
             display: flex;
             flex-direction: column;
             gap: 0.4rem;
+            grid-column: span 12;
+        }
+        .filters-panel__field--span-4 {
+            grid-column: span 4;
+        }
+        .filters-panel__field--span-6 {
+            grid-column: span 6;
         }
         .filters-panel__field label {
             font-weight: 600;
             font-size: 0.85rem;
             color: var(--muted);
+        }
+        @media (max-width: 1024px) {
+            .filters-panel__field--span-4,
+            .filters-panel__field--span-6 {
+                grid-column: span 12;
+            }
         }
         .filters-panel__field .input {
             width: 100%;
@@ -243,35 +256,35 @@
                         <div class="filters-panel__errors">{{ filter_form.non_field_errors }}</div>
                     {% endif %}
                     <div class="filters-panel__fields">
-                        <div class="filters-panel__field">
+                        <div class="filters-panel__field filters-panel__field--span-4">
                             {{ filter_form.username.label_tag }}
                             {{ filter_form.username }}
                             {% if filter_form.username.errors %}
                                 <div class="filters-panel__errors">{{ filter_form.username.errors|join:', ' }}</div>
                             {% endif %}
                         </div>
-                        <div class="filters-panel__field">
+                        <div class="filters-panel__field filters-panel__field--span-4">
                             {{ filter_form.status.label_tag }}
                             {{ filter_form.status }}
                             {% if filter_form.status.errors %}
                                 <div class="filters-panel__errors">{{ filter_form.status.errors|join:', ' }}</div>
                             {% endif %}
                         </div>
-                        <div class="filters-panel__field">
+                        <div class="filters-panel__field filters-panel__field--span-4">
                             {{ filter_form.provider.label_tag }}
                             {{ filter_form.provider }}
                             {% if filter_form.provider.errors %}
                                 <div class="filters-panel__errors">{{ filter_form.provider.errors|join:', ' }}</div>
                             {% endif %}
                         </div>
-                        <div class="filters-panel__field">
+                        <div class="filters-panel__field filters-panel__field--span-6">
                             {{ filter_form.date_from.label_tag }}
                             {{ filter_form.date_from }}
                             {% if filter_form.date_from.errors %}
                                 <div class="filters-panel__errors">{{ filter_form.date_from.errors|join:', ' }}</div>
                             {% endif %}
                         </div>
-                        <div class="filters-panel__field">
+                        <div class="filters-panel__field filters-panel__field--span-6">
                             {{ filter_form.date_to.label_tag }}
                             {{ filter_form.date_to }}
                             {% if filter_form.date_to.errors %}

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -39,6 +39,42 @@
         .pagination .page-item:hover {
             background-color: var(--bg2);
         }
+        .filter-form {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+        .filter-form__grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 1rem;
+        }
+        .filter-form__field label {
+            display: block;
+            margin-bottom: 0.25rem;
+            font-weight: 600;
+        }
+        .filter-form__actions {
+            display: flex;
+            gap: 0.75rem;
+        }
+        .filter-form__actions .btn {
+            padding: 0.5rem 1.25rem;
+            border-radius: 0.5rem;
+            border: none;
+            cursor: pointer;
+            background-color: var(--ring);
+            color: #fff;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .filter-form__actions .btn.btn--secondary {
+            background-color: var(--bg2);
+            color: var(--text);
+        }
     </style>
 {% endblock extra_head %}
 
@@ -55,6 +91,34 @@
     <!-- Card -->
     <section class="card">
         <div class="card__body">
+            <form method="get" class="filter-form">
+                <div class="filter-form__grid">
+                    <div class="filter-form__field">
+                        {{ filter_form.username.label_tag }}
+                        {{ filter_form.username }}
+                    </div>
+                    <div class="filter-form__field">
+                        {{ filter_form.status.label_tag }}
+                        {{ filter_form.status }}
+                    </div>
+                    <div class="filter-form__field">
+                        {{ filter_form.provider.label_tag }}
+                        {{ filter_form.provider }}
+                    </div>
+                    <div class="filter-form__field">
+                        {{ filter_form.date_from.label_tag }}
+                        {{ filter_form.date_from }}
+                    </div>
+                    <div class="filter-form__field">
+                        {{ filter_form.date_to.label_tag }}
+                        {{ filter_form.date_to }}
+                    </div>
+                </div>
+                <div class="filter-form__actions">
+                    <button type="submit" class="btn">Filter</button>
+                    <a href="{% url 'messaging:admin_messages_list' %}" class="btn btn--secondary">Clear</a>
+                </div>
+            </form>
             <!-- Table -->
             <div class="table-wrap">
                 <table>

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -46,20 +46,23 @@
             background-color: var(--bg2);
         }
         .filters-panel {
-            padding: 1.5rem;
-            border: 1px solid rgba(15, 23, 42, 0.06);
+            border: 1px solid rgba(15, 23, 42, 0.08);
             border-radius: calc(var(--radius) + 6px);
-            background: linear-gradient(145deg, rgba(255,255,255,0.88), rgba(255,255,255,0.75));
-            box-shadow: inset 0 1px 0 rgba(255,255,255,0.5), 0 12px 32px rgba(15, 23, 42, 0.12);
+            background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.8));
+            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+            overflow: hidden;
         }
         .filters-panel__summary {
             display: flex;
-            align-items: flex-start;
+            align-items: center;
             justify-content: space-between;
-            gap: 1rem;
+            gap: 1.5rem;
+            padding: 1.4rem 1.6rem;
             cursor: pointer;
             list-style: none;
             margin: 0;
+            background: rgba(255, 255, 255, 0.75);
+            backdrop-filter: blur(6px);
         }
         .filters-panel__summary::-webkit-details-marker {
             display: none;
@@ -67,73 +70,72 @@
         .filters-panel__summary-text {
             display: flex;
             flex-direction: column;
-            gap: 0.35rem;
+            gap: 0.4rem;
         }
         .filters-panel__title {
             margin: 0;
-            font-size: 1.1rem;
+            font-size: 1.05rem;
             font-weight: 600;
+            color: var(--text);
         }
         .filters-panel__subtitle {
-            margin: 0.35rem 0 0;
+            margin: 0;
             color: var(--muted);
-            font-size: 0.9rem;
-        }
-        .filters-panel__result-count {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.4rem;
-            padding: 0.35rem 0.9rem;
-            border-radius: 999px;
-            border: 1px dashed var(--border);
-            background: rgba(15, 23, 42, 0.04);
-            font-size: 0.85rem;
-            color: var(--muted);
+            font-size: 0.92rem;
         }
         .filters-panel__summary-meta {
             display: inline-flex;
             align-items: center;
             gap: 0.75rem;
+            flex-wrap: wrap;
         }
         .filters-panel__summary-badge {
             display: inline-flex;
             align-items: center;
-            justify-content: center;
-            gap: 0.25rem;
-            padding: 0.35rem 0.75rem;
+            gap: 0.4rem;
+            padding: 0.35rem 0.85rem;
             border-radius: 999px;
-            background: rgba(15, 23, 42, 0.08);
-            color: var(--ring);
+            background: rgba(79, 70, 229, 0.12);
+            color: rgba(79, 70, 229, 1);
             font-weight: 600;
             font-size: 0.8rem;
+        }
+        .filters-panel__result-count {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.4rem 0.9rem;
+            border-radius: 999px;
+            border: 1px dashed rgba(148, 163, 184, 0.5);
+            color: var(--muted);
+            font-size: 0.82rem;
         }
         .filters-panel__toggle-icon {
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 2rem;
-            height: 2rem;
+            width: 2.25rem;
+            height: 2.25rem;
             border-radius: 999px;
-            border: 1px solid var(--border);
+            border: 1px solid rgba(148, 163, 184, 0.5);
+            color: rgba(79, 70, 229, 1);
             background: #fff;
-            color: var(--muted);
-            transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-        }
-        .filters-panel__toggle-icon svg {
-            display: block;
+            transition: transform 0.2s ease, color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
         }
         .filters-panel[open] .filters-panel__toggle-icon {
             transform: rotate(180deg);
-            background: var(--ring);
+            background: rgba(79, 70, 229, 1);
             color: #fff;
-            border-color: var(--ring);
-            box-shadow: 0 10px 20px rgba(15, 23, 42, 0.15);
+            border-color: rgba(79, 70, 229, 1);
+            box-shadow: 0 10px 24px rgba(79, 70, 229, 0.35);
         }
         .filters-panel__content {
-            margin-top: 1.25rem;
+            padding: 1.5rem 1.75rem 1.75rem;
+            background: rgba(255, 255, 255, 0.82);
+            backdrop-filter: blur(6px);
             display: flex;
             flex-direction: column;
-            gap: 1.25rem;
+            gap: 1.5rem;
         }
         .filters-panel__form {
             display: flex;
@@ -142,34 +144,22 @@
         }
         .filters-panel__fields {
             display: grid;
-            grid-template-columns: repeat(12, minmax(0, 1fr));
-            gap: 1rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 1.1rem;
         }
         .filters-panel__field {
             display: flex;
             flex-direction: column;
-            gap: 0.4rem;
-            grid-column: span 12;
-        }
-        .filters-panel__field--span-4 {
-            grid-column: span 4;
-        }
-        .filters-panel__field--span-6 {
-            grid-column: span 6;
+            gap: 0.45rem;
         }
         .filters-panel__field label {
             font-weight: 600;
             font-size: 0.85rem;
-            color: var(--muted);
-        }
-        @media (max-width: 1024px) {
-            .filters-panel__field--span-4,
-            .filters-panel__field--span-6 {
-                grid-column: span 12;
-            }
+            color: rgba(30, 41, 59, 0.75);
         }
         .filters-panel__field .input {
             width: 100%;
+            box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.04);
         }
         .filters-panel__errors {
             color: #b91c1c;
@@ -184,24 +174,27 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            gap: 0.35rem;
+            gap: 0.4rem;
             font-size: 0.9rem;
-            padding: 0.55rem 1.4rem;
+            padding: 0.6rem 1.5rem;
+        }
+        .filters-panel__actions .btn-primary {
+            box-shadow: 0 14px 22px rgba(79, 70, 229, 0.28);
         }
         .filters-panel__active {
             display: flex;
             flex-wrap: wrap;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.75rem 1rem;
-            background: rgba(148, 163, 184, 0.12);
+            gap: 0.6rem;
+            padding: 0.9rem 1rem;
             border-radius: 12px;
-            border: 1px solid rgba(148, 163, 184, 0.2);
+            background: rgba(79, 70, 229, 0.08);
+            border: 1px solid rgba(79, 70, 229, 0.16);
         }
         .filters-panel__active-label {
             font-size: 0.85rem;
             font-weight: 600;
-            color: var(--muted);
+            color: rgba(30, 41, 59, 0.6);
+            margin-right: 0.25rem;
         }
         .filters-panel__chip {
             display: inline-flex;
@@ -210,62 +203,34 @@
             padding: 0.45rem 0.75rem;
             border-radius: 999px;
             background: #fff;
-            border: 1px solid rgba(15, 23, 42, 0.12);
-            font-size: 0.8rem;
-            color: var(--muted);
+            border: 1px solid rgba(79, 70, 229, 0.2);
+            font-size: 0.82rem;
+            color: rgba(30, 41, 59, 0.7);
             text-decoration: none;
-            position: relative;
-            overflow: hidden;
-            transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
         }
         .filters-panel__chip:hover,
         .filters-panel__chip:focus,
         .filters-panel__chip:focus-visible {
-            background: rgba(15, 23, 42, 0.08);
-            border-color: rgba(15, 23, 42, 0.18);
-            color: var(--text);
+            transform: translateY(-1px);
+            border-color: rgba(79, 70, 229, 0.45);
+            box-shadow: 0 8px 18px rgba(79, 70, 229, 0.2);
             outline: none;
         }
         .filters-panel__chip-icon {
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 1.5rem;
-            height: 1.5rem;
+            width: 1.4rem;
+            height: 1.4rem;
             border-radius: 999px;
-            border: 1px solid rgba(15, 23, 42, 0.15);
-            background: rgba(239, 68, 68, 0.12);
+            background: rgba(248, 113, 113, 0.18);
             color: rgba(220, 38, 38, 1);
             font-weight: 700;
-            font-size: 0.95rem;
-            transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+            font-size: 0.9rem;
             flex-shrink: 0;
         }
-        .filters-panel__chip:hover .filters-panel__chip-icon,
-        .filters-panel__chip:focus .filters-panel__chip-icon,
-        .filters-panel__chip:focus-visible .filters-panel__chip-icon {
-            background: rgba(220, 38, 38, 0.18);
-            border-color: rgba(220, 38, 38, 0.35);
-            color: #fff;
-        }
-        .filters-panel__chip-text {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.35rem;
-            white-space: nowrap;
-            opacity: 0;
-            max-width: 0;
-            transform: translateX(-0.35rem);
-            transition: opacity 0.2s ease, max-width 0.2s ease, transform 0.2s ease;
-        }
-        .filters-panel__chip:hover .filters-panel__chip-text,
-        .filters-panel__chip:focus .filters-panel__chip-text,
-        .filters-panel__chip:focus-visible .filters-panel__chip-text {
-            opacity: 1;
-            max-width: 18rem;
-            transform: translateX(0);
-        }
-        .filters-panel__chip-text strong {
+        .filters-panel__chip strong {
             color: var(--text);
             font-weight: 600;
         }
@@ -285,8 +250,8 @@
             gap: 0.35rem;
             padding: 0.35rem 0.75rem;
             border-radius: 999px;
-            background: rgba(15, 23, 42, 0.08);
-            color: var(--ring);
+            background: rgba(79, 70, 229, 0.12);
+            color: rgba(79, 70, 229, 1);
             font-weight: 600;
         }
         tbody td:first-child strong,
@@ -307,19 +272,12 @@
             font-size: 0.95rem;
         }
         @media (max-width: 768px) {
-            .filters-panel {
-                padding: 1.25rem;
-            }
             .filters-panel__summary {
                 flex-direction: column;
                 align-items: flex-start;
-                gap: 0.75rem;
             }
-            .filters-panel__summary-meta {
-                width: 100%;
-                flex-wrap: wrap;
-                justify-content: flex-start;
-                gap: 0.5rem;
+            .filters-panel__content {
+                padding: 1.25rem;
             }
             .filters-panel__actions {
                 width: 100%;
@@ -327,6 +285,10 @@
             .filters-panel__actions .btn {
                 flex: 1 1 auto;
                 justify-content: center;
+            }
+            .filters-panel__active {
+                flex-direction: column;
+                align-items: flex-start;
             }
             .table-meta {
                 flex-direction: column;
@@ -376,35 +338,35 @@
                             <div class="filters-panel__errors">{{ filter_form.non_field_errors }}</div>
                         {% endif %}
                         <div class="filters-panel__fields">
-                            <div class="filters-panel__field filters-panel__field--span-4">
+                            <div class="filters-panel__field">
                                 {{ filter_form.user.label_tag }}
                                 {{ filter_form.user }}
                                 {% if filter_form.user.errors %}
                                     <div class="filters-panel__errors">{{ filter_form.user.errors|join:', ' }}</div>
                                 {% endif %}
                             </div>
-                            <div class="filters-panel__field filters-panel__field--span-4">
+                            <div class="filters-panel__field">
                                 {{ filter_form.status.label_tag }}
                                 {{ filter_form.status }}
                                 {% if filter_form.status.errors %}
                                     <div class="filters-panel__errors">{{ filter_form.status.errors|join:', ' }}</div>
                                 {% endif %}
                             </div>
-                            <div class="filters-panel__field filters-panel__field--span-4">
+                            <div class="filters-panel__field">
                                 {{ filter_form.provider.label_tag }}
                                 {{ filter_form.provider }}
                                 {% if filter_form.provider.errors %}
                                     <div class="filters-panel__errors">{{ filter_form.provider.errors|join:', ' }}</div>
                                 {% endif %}
                             </div>
-                            <div class="filters-panel__field filters-panel__field--span-6">
+                            <div class="filters-panel__field">
                                 {{ filter_form.date_from.label_tag }}
                                 {{ filter_form.date_from }}
                                 {% if filter_form.date_from.errors %}
                                     <div class="filters-panel__errors">{{ filter_form.date_from.errors|join:', ' }}</div>
                                 {% endif %}
                             </div>
-                            <div class="filters-panel__field filters-panel__field--span-6">
+                            <div class="filters-panel__field">
                                 {{ filter_form.date_to.label_tag }}
                                 {{ filter_form.date_to }}
                                 {% if filter_form.date_to.errors %}
@@ -421,9 +383,9 @@
                         <div class="filters-panel__active">
                             <span class="filters-panel__active-label">Active filters:</span>
                             {% for chip in active_filter_chips %}
-                                <a href="{{ chip.remove_url }}" class="filters-panel__chip" aria-label="Remove {{ chip.label }} filter" title="{{ chip.label }}: {{ chip.value }}">
+                                <a href="{{ chip.remove_url }}" class="filters-panel__chip" aria-label="Remove {{ chip.label }} filter" title="Remove {{ chip.label }} filter">
                                     <span class="filters-panel__chip-icon" aria-hidden="true">&minus;</span>
-                                    <span class="filters-panel__chip-text">{{ chip.label }}: <strong>{{ chip.value }}</strong></span>
+                                    <span>{{ chip.label }}: <strong>{{ chip.value }}</strong></span>
                                 </a>
                             {% endfor %}
                         </div>

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -302,7 +302,7 @@
                 <summary class="filters-panel__summary">
                     <div class="filters-panel__summary-text">
                         <h2 class="filters-panel__title">Filter messages</h2>
-                        <p class="filters-panel__subtitle">Refine the inbox by username, delivery status, provider, or a custom date range.</p>
+                        <p class="filters-panel__subtitle">Refine the inbox by user, delivery status, provider, or a custom date range.</p>
                     </div>
                     <div class="filters-panel__summary-meta">
                         {% if active_filter_count %}
@@ -326,10 +326,10 @@
                         {% endif %}
                         <div class="filters-panel__fields">
                             <div class="filters-panel__field filters-panel__field--span-4">
-                                {{ filter_form.username.label_tag }}
-                                {{ filter_form.username }}
-                                {% if filter_form.username.errors %}
-                                    <div class="filters-panel__errors">{{ filter_form.username.errors|join:', ' }}</div>
+                                {{ filter_form.user.label_tag }}
+                                {{ filter_form.user }}
+                                {% if filter_form.user.errors %}
+                                    <div class="filters-panel__errors">{{ filter_form.user.errors|join:', ' }}</div>
                                 {% endif %}
                             </div>
                             <div class="filters-panel__field filters-panel__field--span-4">
@@ -369,8 +369,8 @@
                     {% if active_filters %}
                         <div class="filters-panel__active">
                             <span class="filters-panel__active-label">Active filters:</span>
-                            {% if active_filters.username %}
-                                <span class="filters-panel__chip">User: <strong>{{ active_filters.username }}</strong></span>
+                            {% if active_filters.user %}
+                                <span class="filters-panel__chip">User: <strong>{{ active_filter_user_display }}</strong></span>
                             {% endif %}
                             {% if active_filters.status %}
                                 <span class="filters-panel__chip">

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -206,15 +206,66 @@
         .filters-panel__chip {
             display: inline-flex;
             align-items: center;
-            gap: 0.35rem;
-            padding: 0.35rem 0.75rem;
+            gap: 0.5rem;
+            padding: 0.45rem 0.75rem;
             border-radius: 999px;
             background: #fff;
-            border: 1px solid rgba(15, 23, 42, 0.08);
+            border: 1px solid rgba(15, 23, 42, 0.12);
             font-size: 0.8rem;
             color: var(--muted);
+            text-decoration: none;
+            position: relative;
+            overflow: hidden;
+            transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
         }
-        .filters-panel__chip strong {
+        .filters-panel__chip:hover,
+        .filters-panel__chip:focus,
+        .filters-panel__chip:focus-visible {
+            background: rgba(15, 23, 42, 0.08);
+            border-color: rgba(15, 23, 42, 0.18);
+            color: var(--text);
+            outline: none;
+        }
+        .filters-panel__chip-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 1.5rem;
+            height: 1.5rem;
+            border-radius: 999px;
+            border: 1px solid rgba(15, 23, 42, 0.15);
+            background: rgba(239, 68, 68, 0.12);
+            color: rgba(220, 38, 38, 1);
+            font-weight: 700;
+            font-size: 0.95rem;
+            transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+            flex-shrink: 0;
+        }
+        .filters-panel__chip:hover .filters-panel__chip-icon,
+        .filters-panel__chip:focus .filters-panel__chip-icon,
+        .filters-panel__chip:focus-visible .filters-panel__chip-icon {
+            background: rgba(220, 38, 38, 0.18);
+            border-color: rgba(220, 38, 38, 0.35);
+            color: #fff;
+        }
+        .filters-panel__chip-text {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            white-space: nowrap;
+            opacity: 0;
+            max-width: 0;
+            transform: translateX(-0.35rem);
+            transition: opacity 0.2s ease, max-width 0.2s ease, transform 0.2s ease;
+        }
+        .filters-panel__chip:hover .filters-panel__chip-text,
+        .filters-panel__chip:focus .filters-panel__chip-text,
+        .filters-panel__chip:focus-visible .filters-panel__chip-text {
+            opacity: 1;
+            max-width: 18rem;
+            transform: translateX(0);
+        }
+        .filters-panel__chip-text strong {
             color: var(--text);
             font-weight: 600;
         }
@@ -369,28 +420,12 @@
                     {% if active_filters %}
                         <div class="filters-panel__active">
                             <span class="filters-panel__active-label">Active filters:</span>
-                            {% if active_filters.user %}
-                                <span class="filters-panel__chip">User: <strong>{{ active_filter_user_display }}</strong></span>
-                            {% endif %}
-                            {% if active_filters.status %}
-                                <span class="filters-panel__chip">
-                                    Status:
-                                    <strong>
-                                        {% for value, label in filter_form.fields.status.choices %}
-                                            {% if value == active_filters.status %}{{ label }}{% endif %}
-                                        {% endfor %}
-                                    </strong>
-                                </span>
-                            {% endif %}
-                            {% if active_filters.provider %}
-                                <span class="filters-panel__chip">Provider: <strong>{{ active_filters.provider.name }}</strong></span>
-                            {% endif %}
-                            {% if active_filters.date_from %}
-                                <span class="filters-panel__chip">From: <strong>{{ active_filters.date_from|date:'M j, Y' }}</strong></span>
-                            {% endif %}
-                            {% if active_filters.date_to %}
-                                <span class="filters-panel__chip">To: <strong>{{ active_filters.date_to|date:'M j, Y' }}</strong></span>
-                            {% endif %}
+                            {% for chip in active_filter_chips %}
+                                <a href="{{ chip.remove_url }}" class="filters-panel__chip" aria-label="Remove {{ chip.label }} filter" title="{{ chip.label }}: {{ chip.value }}">
+                                    <span class="filters-panel__chip-icon" aria-hidden="true">&minus;</span>
+                                    <span class="filters-panel__chip-text">{{ chip.label }}: <strong>{{ chip.value }}</strong></span>
+                                </a>
+                            {% endfor %}
                         </div>
                     {% endif %}
                 </div>

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -95,8 +95,8 @@
             gap: 0.4rem;
             padding: 0.35rem 0.85rem;
             border-radius: 999px;
-            background: rgba(79, 70, 229, 0.12);
-            color: rgba(79, 70, 229, 1);
+            background: rgba(15, 23, 42, 0.08);
+            color: rgba(15, 23, 42, 0.82);
             font-weight: 600;
             font-size: 0.8rem;
         }
@@ -118,16 +118,16 @@
             height: 2.25rem;
             border-radius: 999px;
             border: 1px solid rgba(148, 163, 184, 0.5);
-            color: rgba(79, 70, 229, 1);
+            color: rgba(15, 23, 42, 0.82);
             background: #fff;
             transition: transform 0.2s ease, color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
         }
         .filters-panel[open] .filters-panel__toggle-icon {
             transform: rotate(180deg);
-            background: rgba(79, 70, 229, 1);
+            background: rgba(15, 23, 42, 1);
             color: #fff;
-            border-color: rgba(79, 70, 229, 1);
-            box-shadow: 0 10px 24px rgba(79, 70, 229, 0.35);
+            border-color: rgba(15, 23, 42, 1);
+            box-shadow: 0 10px 24px rgba(15, 23, 42, 0.3);
         }
         .filters-panel__content {
             padding: 1.5rem 1.75rem 1.75rem;
@@ -179,7 +179,7 @@
             padding: 0.6rem 1.5rem;
         }
         .filters-panel__actions .btn-primary {
-            box-shadow: 0 14px 22px rgba(79, 70, 229, 0.28);
+            box-shadow: 0 14px 22px rgba(15, 23, 42, 0.24);
         }
         .filters-panel__active {
             display: flex;
@@ -187,8 +187,8 @@
             gap: 0.6rem;
             padding: 0.9rem 1rem;
             border-radius: 12px;
-            background: rgba(79, 70, 229, 0.08);
-            border: 1px solid rgba(79, 70, 229, 0.16);
+            background: rgba(15, 23, 42, 0.05);
+            border: 1px solid rgba(15, 23, 42, 0.12);
         }
         .filters-panel__active-label {
             font-size: 0.85rem;
@@ -203,7 +203,7 @@
             padding: 0.45rem 0.75rem;
             border-radius: 999px;
             background: #fff;
-            border: 1px solid rgba(79, 70, 229, 0.2);
+            border: 1px solid rgba(15, 23, 42, 0.18);
             font-size: 0.82rem;
             color: rgba(30, 41, 59, 0.7);
             text-decoration: none;
@@ -213,8 +213,8 @@
         .filters-panel__chip:focus,
         .filters-panel__chip:focus-visible {
             transform: translateY(-1px);
-            border-color: rgba(79, 70, 229, 0.45);
-            box-shadow: 0 8px 18px rgba(79, 70, 229, 0.2);
+            border-color: rgba(15, 23, 42, 0.35);
+            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
             outline: none;
         }
         .filters-panel__chip-icon {
@@ -250,8 +250,8 @@
             gap: 0.35rem;
             padding: 0.35rem 0.75rem;
             border-radius: 999px;
-            background: rgba(79, 70, 229, 0.12);
-            color: rgba(79, 70, 229, 1);
+            background: rgba(15, 23, 42, 0.08);
+            color: rgba(15, 23, 42, 0.82);
             font-weight: 600;
         }
         tbody td:first-child strong,

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -8,18 +8,23 @@
         .pagination {
             display: flex;
             justify-content: center;
-            margin-top: 1rem;
+            margin-top: 1.5rem;
             gap: 0.5rem;
+            flex-wrap: wrap;
         }
         .pagination .page-item {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 2.5rem;
             padding: 0.5rem 0.75rem;
-            border-radius: 0.5rem;
+            border-radius: 999px;
             color: var(--text);
             background-color: #fff;
             border: 1px solid var(--border);
             text-decoration: none;
-            transition: background-color 0.2s;
+            font-weight: 500;
+            transition: background-color 0.2s, color 0.2s, border-color 0.2s;
         }
         .pagination .page-item.ellipsis {
             pointer-events: none;
@@ -30,6 +35,7 @@
             background-color: var(--ring);
             color: #fff;
             border-color: var(--ring);
+            box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
         }
         .pagination .page-item.disabled {
             color: var(--muted);
@@ -39,41 +45,169 @@
         .pagination .page-item:hover {
             background-color: var(--bg2);
         }
-        .filter-form {
+        .filters-panel {
             display: flex;
             flex-direction: column;
-            gap: 1rem;
-            margin-bottom: 1.5rem;
+            gap: 1.25rem;
+            padding: 1.5rem;
+            border: 1px solid rgba(15, 23, 42, 0.06);
+            border-radius: calc(var(--radius) + 6px);
+            background: linear-gradient(145deg, rgba(255,255,255,0.88), rgba(255,255,255,0.75));
+            box-shadow: inset 0 1px 0 rgba(255,255,255,0.5), 0 12px 32px rgba(15, 23, 42, 0.12);
         }
-        .filter-form__grid {
+        .filters-panel__header {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+        .filters-panel__title {
+            margin: 0;
+            font-size: 1.1rem;
+            font-weight: 600;
+        }
+        .filters-panel__subtitle {
+            margin: 0.35rem 0 0;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+        .filters-panel__result-count {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.35rem 0.9rem;
+            border-radius: 999px;
+            border: 1px dashed var(--border);
+            background: rgba(15, 23, 42, 0.04);
+            font-size: 0.85rem;
+            color: var(--muted);
+        }
+        .filters-panel__form {
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+        .filters-panel__fields {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
             gap: 1rem;
         }
-        .filter-form__field label {
-            display: block;
-            margin-bottom: 0.25rem;
-            font-weight: 600;
-        }
-        .filter-form__actions {
+        .filters-panel__field {
             display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+        }
+        .filters-panel__field label {
+            font-weight: 600;
+            font-size: 0.85rem;
+            color: var(--muted);
+        }
+        .filters-panel__field .input {
+            width: 100%;
+        }
+        .filters-panel__errors {
+            color: #b91c1c;
+            font-size: 0.8rem;
+        }
+        .filters-panel__actions {
+            display: flex;
+            flex-wrap: wrap;
             gap: 0.75rem;
         }
-        .filter-form__actions .btn {
-            padding: 0.5rem 1.25rem;
-            border-radius: 0.5rem;
-            border: none;
-            cursor: pointer;
-            background-color: var(--ring);
-            color: #fff;
-            text-decoration: none;
+        .filters-panel__actions .btn {
             display: inline-flex;
             align-items: center;
             justify-content: center;
+            gap: 0.35rem;
+            font-size: 0.9rem;
+            padding: 0.55rem 1.4rem;
         }
-        .filter-form__actions .btn.btn--secondary {
-            background-color: var(--bg2);
+        .filters-panel__active {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1rem;
+            background: rgba(148, 163, 184, 0.12);
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.2);
+        }
+        .filters-panel__active-label {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--muted);
+        }
+        .filters-panel__chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            background: #fff;
+            border: 1px solid rgba(15, 23, 42, 0.08);
+            font-size: 0.8rem;
+            color: var(--muted);
+        }
+        .filters-panel__chip strong {
             color: var(--text);
+            font-weight: 600;
+        }
+        .table-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            margin: 1.5rem 0 0.75rem;
+            flex-wrap: wrap;
+            color: var(--muted);
+            font-size: 0.85rem;
+        }
+        .table-meta__highlight {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            background: rgba(15, 23, 42, 0.08);
+            color: var(--ring);
+            font-weight: 600;
+        }
+        tbody td:first-child strong,
+        tbody td:nth-child(2) strong {
+            color: var(--ring);
+        }
+        tbody td .message-preview {
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 2;
+            overflow: hidden;
+            color: var(--muted);
+        }
+        .empty-state {
+            padding: 2.5rem 1rem;
+            text-align: center;
+            color: var(--muted);
+            font-size: 0.95rem;
+        }
+        @media (max-width: 768px) {
+            .filters-panel {
+                padding: 1.25rem;
+            }
+            .filters-panel__header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .filters-panel__actions {
+                width: 100%;
+            }
+            .filters-panel__actions .btn {
+                flex: 1 1 auto;
+                justify-content: center;
+            }
+            .table-meta {
+                flex-direction: column;
+                align-items: flex-start;
+            }
         }
     </style>
 {% endblock extra_head %}
@@ -91,45 +225,117 @@
     <!-- Card -->
     <section class="card">
         <div class="card__body">
-            <form method="get" class="filter-form">
-                <div class="filter-form__grid">
-                    <div class="filter-form__field">
-                        {{ filter_form.username.label_tag }}
-                        {{ filter_form.username }}
+            <div class="filters-panel">
+                <div class="filters-panel__header">
+                    <div>
+                        <h2 class="filters-panel__title">Filter messages</h2>
+                        <p class="filters-panel__subtitle">Refine the inbox by username, delivery status, provider, or a custom date range.</p>
                     </div>
-                    <div class="filter-form__field">
-                        {{ filter_form.status.label_tag }}
-                        {{ filter_form.status }}
-                    </div>
-                    <div class="filter-form__field">
-                        {{ filter_form.provider.label_tag }}
-                        {{ filter_form.provider }}
-                    </div>
-                    <div class="filter-form__field">
-                        {{ filter_form.date_from.label_tag }}
-                        {{ filter_form.date_from }}
-                    </div>
-                    <div class="filter-form__field">
-                        {{ filter_form.date_to.label_tag }}
-                        {{ filter_form.date_to }}
-                    </div>
+                    {% if page_obj %}
+                        <span class="filters-panel__result-count">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M12 3C7.031 3 3 7.031 3 12C3 16.969 7.031 21 12 21C16.969 21 21 16.969 21 12C21 7.031 16.969 3 12 3ZM12 19.5C7.863 19.5 4.5 16.137 4.5 12C4.5 7.863 7.863 4.5 12 4.5C16.137 4.5 19.5 7.863 19.5 12C19.5 16.137 16.137 19.5 12 19.5ZM16.219 9.469L11 14.688L7.781 11.469L8.844 10.406L11 12.563L15.156 8.406L16.219 9.469Z" fill="currentColor"/></svg>
+                            {{ page_obj.paginator.count }} messages
+                        </span>
+                    {% endif %}
                 </div>
-                <div class="filter-form__actions">
-                    <button type="submit" class="btn">Filter</button>
-                    <a href="{% url 'messaging:admin_messages_list' %}" class="btn btn--secondary">Clear</a>
+                <form method="get" class="filters-panel__form" novalidate>
+                    {% if filter_form.non_field_errors %}
+                        <div class="filters-panel__errors">{{ filter_form.non_field_errors }}</div>
+                    {% endif %}
+                    <div class="filters-panel__fields">
+                        <div class="filters-panel__field">
+                            {{ filter_form.username.label_tag }}
+                            {{ filter_form.username }}
+                            {% if filter_form.username.errors %}
+                                <div class="filters-panel__errors">{{ filter_form.username.errors|join:', ' }}</div>
+                            {% endif %}
+                        </div>
+                        <div class="filters-panel__field">
+                            {{ filter_form.status.label_tag }}
+                            {{ filter_form.status }}
+                            {% if filter_form.status.errors %}
+                                <div class="filters-panel__errors">{{ filter_form.status.errors|join:', ' }}</div>
+                            {% endif %}
+                        </div>
+                        <div class="filters-panel__field">
+                            {{ filter_form.provider.label_tag }}
+                            {{ filter_form.provider }}
+                            {% if filter_form.provider.errors %}
+                                <div class="filters-panel__errors">{{ filter_form.provider.errors|join:', ' }}</div>
+                            {% endif %}
+                        </div>
+                        <div class="filters-panel__field">
+                            {{ filter_form.date_from.label_tag }}
+                            {{ filter_form.date_from }}
+                            {% if filter_form.date_from.errors %}
+                                <div class="filters-panel__errors">{{ filter_form.date_from.errors|join:', ' }}</div>
+                            {% endif %}
+                        </div>
+                        <div class="filters-panel__field">
+                            {{ filter_form.date_to.label_tag }}
+                            {{ filter_form.date_to }}
+                            {% if filter_form.date_to.errors %}
+                                <div class="filters-panel__errors">{{ filter_form.date_to.errors|join:', ' }}</div>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="filters-panel__actions">
+                        <button type="submit" class="btn btn-primary">Filter</button>
+                        <a href="{% url 'messaging:admin_messages_list' %}" class="btn btn-ghost">Clear</a>
+                    </div>
+                </form>
+                {% if filter_form.is_bound and filter_form.is_valid %}
+                    {% with data=filter_form.cleaned_data %}
+                        {% if data.username or data.status or data.provider or data.date_from or data.date_to %}
+                            <div class="filters-panel__active">
+                                <span class="filters-panel__active-label">Active filters:</span>
+                                {% if data.username %}
+                                    <span class="filters-panel__chip">User: <strong>{{ data.username }}</strong></span>
+                                {% endif %}
+                                {% if data.status %}
+                                    <span class="filters-panel__chip">
+                                        Status:
+                                        <strong>
+                                            {% for value, label in filter_form.fields.status.choices %}
+                                                {% if value == data.status %}{{ label }}{% endif %}
+                                            {% endfor %}
+                                        </strong>
+                                    </span>
+                                {% endif %}
+                                {% if data.provider %}
+                                    <span class="filters-panel__chip">Provider: <strong>{{ data.provider.name }}</strong></span>
+                                {% endif %}
+                                {% if data.date_from %}
+                                    <span class="filters-panel__chip">From: <strong>{{ data.date_from|date:'M j, Y' }}</strong></span>
+                                {% endif %}
+                                {% if data.date_to %}
+                                    <span class="filters-panel__chip">To: <strong>{{ data.date_to|date:'M j, Y' }}</strong></span>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    {% endwith %}
+                {% endif %}
+            </div>
+
+            {% if page_obj %}
+            <div class="table-meta">
+                <div>
+                    Showing page {{ page_obj.number }}{% if page_obj.paginator.num_pages %} of {{ page_obj.paginator.num_pages }}{% endif %}
                 </div>
-            </form>
-            <!-- Table -->
+                <div class="table-meta__highlight">{{ message_list|length }} results on this page</div>
+            </div>
+            {% endif %}
+
             <div class="table-wrap">
                 <table>
                     <thead>
                         <tr>
                             <th>User</th>
                             <th>Recipient</th>
-                            <th>Text</th>
+                            <th>Message preview</th>
                             <th>Status</th>
                             <th>Provider</th>
-                            <th>Cost (IRT)</th>
+                            <th class="text-right">Cost (IRT)</th>
                             <th>Date Sent</th>
                         </tr>
                     </thead>
@@ -138,22 +344,22 @@
                         <tr>
                             <td><strong>{{ message.user.username }}</strong></td>
                             <td><strong><a href="{% url 'messaging:admin_message_detail' message.tracking_id %}">{{ message.recipient }}</a></strong></td>
-                            <td>{{ message.text|truncatechars:50 }}</td>
+                            <td><span class="message-preview">{{ message.text }}</span></td>
                             <td>
                                 <span class="pill {{ message.status_pill_class }}">{{ message.get_status_display }}</span>
                                 {% if message.status == 'AWAITING_RETRY' and message.error_message %}
-                                    <div class="error">{{ message.error_message }}</div>
+                                    <div class="filters-panel__errors">{{ message.error_message }}</div>
                                 {% endif %}
                             </td>
                             <td>{{ message.provider.name }}</td>
-                            <td>{{ message.cost|rial_to_toman|default:"N/A" }}</td>
+                            <td class="text-right">{{ message.cost|rial_to_toman|default:"N/A" }}</td>
                             {% with timestamp=message.delivered_at|default:message.sent_at|default:message.created_at %}
                                 <td class="utc-time" data-utc="{{ timestamp|date:'c' }}"></td>
                             {% endwith %}
                         </tr>
                         {% empty %}
                         <tr>
-                            <td colspan="7">No messages found.</td>
+                            <td colspan="7" class="empty-state">No messages match the selected filters yet.</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/server-b/messaging/templates/messaging/admin_message_list.html
+++ b/server-b/messaging/templates/messaging/admin_message_list.html
@@ -46,20 +46,28 @@
             background-color: var(--bg2);
         }
         .filters-panel {
-            display: flex;
-            flex-direction: column;
-            gap: 1.25rem;
             padding: 1.5rem;
             border: 1px solid rgba(15, 23, 42, 0.06);
             border-radius: calc(var(--radius) + 6px);
             background: linear-gradient(145deg, rgba(255,255,255,0.88), rgba(255,255,255,0.75));
             box-shadow: inset 0 1px 0 rgba(255,255,255,0.5), 0 12px 32px rgba(15, 23, 42, 0.12);
         }
-        .filters-panel__header {
+        .filters-panel__summary {
             display: flex;
             align-items: flex-start;
             justify-content: space-between;
             gap: 1rem;
+            cursor: pointer;
+            list-style: none;
+            margin: 0;
+        }
+        .filters-panel__summary::-webkit-details-marker {
+            display: none;
+        }
+        .filters-panel__summary-text {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
         }
         .filters-panel__title {
             margin: 0;
@@ -81,6 +89,51 @@
             background: rgba(15, 23, 42, 0.04);
             font-size: 0.85rem;
             color: var(--muted);
+        }
+        .filters-panel__summary-meta {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+        .filters-panel__summary-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.25rem;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            background: rgba(15, 23, 42, 0.08);
+            color: var(--ring);
+            font-weight: 600;
+            font-size: 0.8rem;
+        }
+        .filters-panel__toggle-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 2rem;
+            height: 2rem;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: #fff;
+            color: var(--muted);
+            transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+        }
+        .filters-panel__toggle-icon svg {
+            display: block;
+        }
+        .filters-panel[open] .filters-panel__toggle-icon {
+            transform: rotate(180deg);
+            background: var(--ring);
+            color: #fff;
+            border-color: var(--ring);
+            box-shadow: 0 10px 20px rgba(15, 23, 42, 0.15);
+        }
+        .filters-panel__content {
+            margin-top: 1.25rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
         }
         .filters-panel__form {
             display: flex;
@@ -206,9 +259,16 @@
             .filters-panel {
                 padding: 1.25rem;
             }
-            .filters-panel__header {
+            .filters-panel__summary {
                 flex-direction: column;
                 align-items: flex-start;
+                gap: 0.75rem;
+            }
+            .filters-panel__summary-meta {
+                width: 100%;
+                flex-wrap: wrap;
+                justify-content: flex-start;
+                gap: 0.5rem;
             }
             .filters-panel__actions {
                 width: 100%;
@@ -238,97 +298,103 @@
     <!-- Card -->
     <section class="card">
         <div class="card__body">
-            <div class="filters-panel">
-                <div class="filters-panel__header">
-                    <div>
+            <details class="filters-panel"{% if filter_panel_open %} open{% endif %}>
+                <summary class="filters-panel__summary">
+                    <div class="filters-panel__summary-text">
                         <h2 class="filters-panel__title">Filter messages</h2>
                         <p class="filters-panel__subtitle">Refine the inbox by username, delivery status, provider, or a custom date range.</p>
                     </div>
-                    {% if page_obj %}
-                        <span class="filters-panel__result-count">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M12 3C7.031 3 3 7.031 3 12C3 16.969 7.031 21 12 21C16.969 21 21 16.969 21 12C21 7.031 16.969 3 12 3ZM12 19.5C7.863 19.5 4.5 16.137 4.5 12C4.5 7.863 7.863 4.5 12 4.5C16.137 4.5 19.5 7.863 19.5 12C19.5 16.137 16.137 19.5 12 19.5ZM16.219 9.469L11 14.688L7.781 11.469L8.844 10.406L11 12.563L15.156 8.406L16.219 9.469Z" fill="currentColor"/></svg>
-                            {{ page_obj.paginator.count }} messages
+                    <div class="filters-panel__summary-meta">
+                        {% if active_filter_count %}
+                            <span class="filters-panel__summary-badge">{{ active_filter_count }} active</span>
+                        {% endif %}
+                        {% if page_obj %}
+                            <span class="filters-panel__result-count">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M12 3C7.031 3 3 7.031 3 12C3 16.969 7.031 21 12 21C16.969 21 21 16.969 21 12C21 7.031 16.969 3 12 3ZM12 19.5C7.863 19.5 4.5 16.137 4.5 12C4.5 7.863 7.863 4.5 12 4.5C16.137 4.5 19.5 7.863 19.5 12C19.5 16.137 16.137 19.5 12 19.5ZM16.219 9.469L11 14.688L7.781 11.469L8.844 10.406L11 12.563L15.156 8.406L16.219 9.469Z" fill="currentColor"/></svg>
+                                {{ page_obj.paginator.count }} messages
+                            </span>
+                        {% endif %}
+                        <span class="filters-panel__toggle-icon" aria-hidden="true">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 8L18 14H6L12 8Z" fill="currentColor"/></svg>
                         </span>
-                    {% endif %}
-                </div>
-                <form method="get" class="filters-panel__form" novalidate>
-                    {% if filter_form.non_field_errors %}
-                        <div class="filters-panel__errors">{{ filter_form.non_field_errors }}</div>
-                    {% endif %}
-                    <div class="filters-panel__fields">
-                        <div class="filters-panel__field filters-panel__field--span-4">
-                            {{ filter_form.username.label_tag }}
-                            {{ filter_form.username }}
-                            {% if filter_form.username.errors %}
-                                <div class="filters-panel__errors">{{ filter_form.username.errors|join:', ' }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="filters-panel__field filters-panel__field--span-4">
-                            {{ filter_form.status.label_tag }}
-                            {{ filter_form.status }}
-                            {% if filter_form.status.errors %}
-                                <div class="filters-panel__errors">{{ filter_form.status.errors|join:', ' }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="filters-panel__field filters-panel__field--span-4">
-                            {{ filter_form.provider.label_tag }}
-                            {{ filter_form.provider }}
-                            {% if filter_form.provider.errors %}
-                                <div class="filters-panel__errors">{{ filter_form.provider.errors|join:', ' }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="filters-panel__field filters-panel__field--span-6">
-                            {{ filter_form.date_from.label_tag }}
-                            {{ filter_form.date_from }}
-                            {% if filter_form.date_from.errors %}
-                                <div class="filters-panel__errors">{{ filter_form.date_from.errors|join:', ' }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="filters-panel__field filters-panel__field--span-6">
-                            {{ filter_form.date_to.label_tag }}
-                            {{ filter_form.date_to }}
-                            {% if filter_form.date_to.errors %}
-                                <div class="filters-panel__errors">{{ filter_form.date_to.errors|join:', ' }}</div>
-                            {% endif %}
-                        </div>
                     </div>
-                    <div class="filters-panel__actions">
-                        <button type="submit" class="btn btn-primary">Filter</button>
-                        <a href="{% url 'messaging:admin_messages_list' %}" class="btn btn-ghost">Clear</a>
-                    </div>
-                </form>
-                {% if filter_form.is_bound and filter_form.is_valid %}
-                    {% with data=filter_form.cleaned_data %}
-                        {% if data.username or data.status or data.provider or data.date_from or data.date_to %}
-                            <div class="filters-panel__active">
-                                <span class="filters-panel__active-label">Active filters:</span>
-                                {% if data.username %}
-                                    <span class="filters-panel__chip">User: <strong>{{ data.username }}</strong></span>
-                                {% endif %}
-                                {% if data.status %}
-                                    <span class="filters-panel__chip">
-                                        Status:
-                                        <strong>
-                                            {% for value, label in filter_form.fields.status.choices %}
-                                                {% if value == data.status %}{{ label }}{% endif %}
-                                            {% endfor %}
-                                        </strong>
-                                    </span>
-                                {% endif %}
-                                {% if data.provider %}
-                                    <span class="filters-panel__chip">Provider: <strong>{{ data.provider.name }}</strong></span>
-                                {% endif %}
-                                {% if data.date_from %}
-                                    <span class="filters-panel__chip">From: <strong>{{ data.date_from|date:'M j, Y' }}</strong></span>
-                                {% endif %}
-                                {% if data.date_to %}
-                                    <span class="filters-panel__chip">To: <strong>{{ data.date_to|date:'M j, Y' }}</strong></span>
+                </summary>
+                <div class="filters-panel__content">
+                    <form method="get" class="filters-panel__form" novalidate>
+                        {% if filter_form.non_field_errors %}
+                            <div class="filters-panel__errors">{{ filter_form.non_field_errors }}</div>
+                        {% endif %}
+                        <div class="filters-panel__fields">
+                            <div class="filters-panel__field filters-panel__field--span-4">
+                                {{ filter_form.username.label_tag }}
+                                {{ filter_form.username }}
+                                {% if filter_form.username.errors %}
+                                    <div class="filters-panel__errors">{{ filter_form.username.errors|join:', ' }}</div>
                                 {% endif %}
                             </div>
-                        {% endif %}
-                    {% endwith %}
-                {% endif %}
-            </div>
+                            <div class="filters-panel__field filters-panel__field--span-4">
+                                {{ filter_form.status.label_tag }}
+                                {{ filter_form.status }}
+                                {% if filter_form.status.errors %}
+                                    <div class="filters-panel__errors">{{ filter_form.status.errors|join:', ' }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="filters-panel__field filters-panel__field--span-4">
+                                {{ filter_form.provider.label_tag }}
+                                {{ filter_form.provider }}
+                                {% if filter_form.provider.errors %}
+                                    <div class="filters-panel__errors">{{ filter_form.provider.errors|join:', ' }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="filters-panel__field filters-panel__field--span-6">
+                                {{ filter_form.date_from.label_tag }}
+                                {{ filter_form.date_from }}
+                                {% if filter_form.date_from.errors %}
+                                    <div class="filters-panel__errors">{{ filter_form.date_from.errors|join:', ' }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="filters-panel__field filters-panel__field--span-6">
+                                {{ filter_form.date_to.label_tag }}
+                                {{ filter_form.date_to }}
+                                {% if filter_form.date_to.errors %}
+                                    <div class="filters-panel__errors">{{ filter_form.date_to.errors|join:', ' }}</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div class="filters-panel__actions">
+                            <button type="submit" class="btn btn-primary">Filter</button>
+                            <a href="{% url 'messaging:admin_messages_list' %}" class="btn btn-ghost">Clear</a>
+                        </div>
+                    </form>
+                    {% if active_filters %}
+                        <div class="filters-panel__active">
+                            <span class="filters-panel__active-label">Active filters:</span>
+                            {% if active_filters.username %}
+                                <span class="filters-panel__chip">User: <strong>{{ active_filters.username }}</strong></span>
+                            {% endif %}
+                            {% if active_filters.status %}
+                                <span class="filters-panel__chip">
+                                    Status:
+                                    <strong>
+                                        {% for value, label in filter_form.fields.status.choices %}
+                                            {% if value == active_filters.status %}{{ label }}{% endif %}
+                                        {% endfor %}
+                                    </strong>
+                                </span>
+                            {% endif %}
+                            {% if active_filters.provider %}
+                                <span class="filters-panel__chip">Provider: <strong>{{ active_filters.provider.name }}</strong></span>
+                            {% endif %}
+                            {% if active_filters.date_from %}
+                                <span class="filters-panel__chip">From: <strong>{{ active_filters.date_from|date:'M j, Y' }}</strong></span>
+                            {% endif %}
+                            {% if active_filters.date_to %}
+                                <span class="filters-panel__chip">To: <strong>{{ active_filters.date_to|date:'M j, Y' }}</strong></span>
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                </div>
+            </details>
 
             {% if page_obj %}
             <div class="table-meta">

--- a/server-b/messaging/tests.py
+++ b/server-b/messaging/tests.py
@@ -356,6 +356,32 @@ class AdminMessageListViewTests(TestCase):
         self.assertNotIn(wrong_provider, message_list)
         self.assertNotIn(outside_range, message_list)
 
+    def test_filter_panel_closed_by_default(self):
+        self.client.login(username="admin", password="pass")
+        url = reverse("messaging:admin_messages_list")
+        response = self.client.get(url)
+
+        self.assertFalse(response.context["filter_panel_open"])
+        self.assertEqual(response.context["active_filter_count"], 0)
+        self.assertEqual(response.context["active_filters"], {})
+
+    def test_filter_panel_reports_active_filters(self):
+        self.client.login(username="admin", password="pass")
+        url = reverse("messaging:admin_messages_list")
+        response = self.client.get(url, {"username": "adm"})
+
+        self.assertTrue(response.context["filter_panel_open"])
+        self.assertEqual(response.context["active_filter_count"], 1)
+        self.assertEqual(response.context["active_filters"]["username"], "adm")
+
+    def test_filter_panel_opens_when_form_has_errors(self):
+        self.client.login(username="admin", password="pass")
+        url = reverse("messaging:admin_messages_list")
+        response = self.client.get(url, {"date_from": "2024-13-01"})
+
+        self.assertTrue(response.context["filter_panel_open"])
+        self.assertTrue(response.context["filter_form"].errors)
+
 
 class ProcessOutboundSmsTaskTests(TestCase):
     def setUp(self):

--- a/server-b/messaging/tests.py
+++ b/server-b/messaging/tests.py
@@ -91,6 +91,25 @@ class MessageModelTests(TestCase):
         self.assertEqual(msg.status_pill_class, "pill--on")
 
 
+class MessageFilterFormRenderingTests(TestCase):
+    def test_widgets_have_consistent_styling(self):
+        form = MessageFilterForm()
+
+        self.assertEqual(form.fields["username"].widget.attrs.get("class"), "input")
+        self.assertEqual(form.fields["username"].widget.attrs.get("placeholder"), "Search username")
+
+        self.assertEqual(form.fields["status"].widget.attrs.get("class"), "input")
+        self.assertEqual(form.fields["status"].choices[0], ("", "All statuses"))
+
+        self.assertEqual(form.fields["provider"].widget.attrs.get("class"), "input")
+        self.assertEqual(form.fields["provider"].empty_label, "All providers")
+
+        self.assertEqual(getattr(form.fields["date_from"].widget, "input_type", None), "date")
+        self.assertEqual(form.fields["date_from"].widget.attrs.get("class"), "input")
+        self.assertEqual(getattr(form.fields["date_to"].widget, "input_type", None), "date")
+        self.assertEqual(form.fields["date_to"].widget.attrs.get("class"), "input")
+
+
 class UserMessageListViewTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user("user", password="pass")
@@ -1256,8 +1275,8 @@ class AdminMessageListViewTests(TestCase):
         url = reverse("messaging:admin_messages_list")
         response = self.client.get(url)
 
-        self.assertContains(response, "<th>Cost (IRT)</th>", html=True)
-        self.assertContains(response, "<td>2500</td>", html=True)
+        self.assertContains(response, '<th class="text-right">Cost (IRT)</th>', html=True)
+        self.assertContains(response, '<td class="text-right">2500</td>', html=True)
 
     def test_cost_column_shows_na_when_unavailable(self):
         self.message.cost = None
@@ -1267,8 +1286,8 @@ class AdminMessageListViewTests(TestCase):
         url = reverse("messaging:admin_messages_list")
         response = self.client.get(url)
 
-        self.assertContains(response, "<th>Cost (IRT)</th>", html=True)
-        self.assertContains(response, "<td>N/A</td>", html=True)
+        self.assertContains(response, '<th class="text-right">Cost (IRT)</th>', html=True)
+        self.assertContains(response, '<td class="text-right">N/A</td>', html=True)
 
     def test_status_pill_and_timestamp_use_delivery_information(self):
         delivered_at = timezone.now().replace(microsecond=0)

--- a/server-b/messaging/views.py
+++ b/server-b/messaging/views.py
@@ -75,7 +75,13 @@ class AdminMessageListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['filter_form'] = getattr(self, 'filter_form', MessageFilterForm())
+        filter_form = getattr(self, 'filter_form', MessageFilterForm(self.request.GET or None))
+        active_filters = filter_form.get_active_filters()
+
+        context['filter_form'] = filter_form
+        context['active_filters'] = active_filters
+        context['active_filter_count'] = len(active_filters)
+        context['filter_panel_open'] = bool(active_filters or filter_form.errors)
         paginator = context.get('paginator')
         page_obj = context.get('page_obj')
         if paginator and page_obj:

--- a/server-b/messaging/views.py
+++ b/server-b/messaging/views.py
@@ -51,9 +51,9 @@ class AdminMessageListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
         if self.filter_form.is_valid():
             data = self.filter_form.cleaned_data
 
-            username = data.get('username')
-            if username:
-                queryset = queryset.filter(user__username__icontains=username)
+            user = data.get('user')
+            if user:
+                queryset = queryset.filter(user=user)
 
             status = data.get('status')
             if status:
@@ -82,6 +82,11 @@ class AdminMessageListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
         context['active_filters'] = active_filters
         context['active_filter_count'] = len(active_filters)
         context['filter_panel_open'] = bool(active_filters or filter_form.errors)
+        user_filter_display = None
+        user_value = active_filters.get('user') if active_filters else None
+        if user_value:
+            user_filter_display = filter_form.fields['user'].label_from_instance(user_value)
+        context['active_filter_user_display'] = user_filter_display
         paginator = context.get('paginator')
         page_obj = context.get('page_obj')
         if paginator and page_obj:


### PR DESCRIPTION
## Summary
- add a MessageFilterForm with username, status, provider, and date range fields for admin filtering
- wire the admin message list view to apply the new filters and expose the form to templates
- render the filter form in the admin message list page and cover the behaviour with new tests

## Testing
- python manage.py test messaging

------
https://chatgpt.com/codex/tasks/task_e_68da4415634c8324837440e4de06e9b8