### PR TITLE
Add time support to admin message filters

### DIFF
--- a/server-b/messaging/forms.py
+++ b/server-b/messaging/forms.py
@@ -1,5 +1,3 @@
-from datetime import datetime, time
-
 from django import forms
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -12,8 +10,8 @@ from .models import MessageStatus
 User = get_user_model()
 
 
-class DatePickerInput(forms.DateInput):
-    input_type = "date"
+class DateTimePickerInput(forms.DateTimeInput):
+    input_type = "datetime-local"
 
 
 class UserChoiceField(forms.ModelChoiceField):
@@ -55,25 +53,29 @@ class MessageFilterForm(forms.Form):
             }
         ),
     )
-    date_from = forms.DateField(
+    date_from = forms.DateTimeField(
         required=False,
-        widget=DatePickerInput(
+        input_formats=["%Y-%m-%dT%H:%M"],
+        widget=DateTimePickerInput(
             attrs={
                 "class": "input",
                 "placeholder": "From",
+                "step": 60,
             }
         ),
-        label="From date",
+        label="From date & time",
     )
-    date_to = forms.DateField(
+    date_to = forms.DateTimeField(
         required=False,
-        widget=DatePickerInput(
+        input_formats=["%Y-%m-%dT%H:%M"],
+        widget=DateTimePickerInput(
             attrs={
                 "class": "input",
                 "placeholder": "To",
+                "step": 60,
             }
         ),
-        label="To date",
+        label="To date & time",
     )
 
     def __init__(self, *args, **kwargs):
@@ -94,19 +96,17 @@ class MessageFilterForm(forms.Form):
         date_from = self.cleaned_data.get("date_from")
         if not date_from:
             return None
-        start = datetime.combine(date_from, time.min)
-        if timezone.is_naive(start):
-            start = timezone.make_aware(start, timezone.get_current_timezone())
-        return start
+        if timezone.is_naive(date_from):
+            date_from = timezone.make_aware(date_from, timezone.get_current_timezone())
+        return date_from
 
     def get_date_to_datetime(self):
         date_to = self.cleaned_data.get("date_to")
         if not date_to:
             return None
-        end = datetime.combine(date_to, time.max)
-        if timezone.is_naive(end):
-            end = timezone.make_aware(end, timezone.get_current_timezone())
-        return end
+        if timezone.is_naive(date_to):
+            date_to = timezone.make_aware(date_to, timezone.get_current_timezone())
+        return date_to
 
     def get_active_filters(self):
         if not self.is_bound:

--- a/server-b/messaging/views.py
+++ b/server-b/messaging/views.py
@@ -141,7 +141,7 @@ class AdminMessageListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
                 {
                     'field': 'date_from',
                     'label': filter_form.fields['date_from'].label,
-                    'value': dateformat.format(date_from_value, 'M j, Y'),
+                    'value': dateformat.format(date_from_value, 'M j, Y H:i'),
                     'remove_url': build_remove_url('date_from'),
                 }
             )
@@ -152,7 +152,7 @@ class AdminMessageListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
                 {
                     'field': 'date_to',
                     'label': filter_form.fields['date_to'].label,
-                    'value': dateformat.format(date_to_value, 'M j, Y'),
+                    'value': dateformat.format(date_to_value, 'M j, Y H:i'),
                     'remove_url': build_remove_url('date_to'),
                 }
             )


### PR DESCRIPTION
## Summary
- allow administrators to include hours and minutes when filtering messages by replacing the date pickers with datetime pickers
- ensure filter chips show the selected time range and update the associated tests for the new input format

## Testing
- python manage.py test messaging.tests.MessageFilterFormRenderingTests messaging.tests.AdminMessageListViewTests -v 2


------
https://chatgpt.com/codex/tasks/task_e_68db7e062fb883248b71bf25af76a5e4